### PR TITLE
Phase 2: Database + Auth — SQLite layer with user profile and query history

### DIFF
--- a/lib/core/constants/strings_tamil.dart
+++ b/lib/core/constants/strings_tamil.dart
@@ -38,4 +38,6 @@ class TamilStrings {
   static const String errorGeneral = 'பிழை ஏற்பட்டது. மீண்டும் முயற்சிக்கவும்.';
   static const String errorMicrophone = 'மைக்ரோஃபோன் அணுக முடியவில்லை';
   static const String errorNetwork = 'இணைய இணைப்பு இல்லை';
+  static const String errorDatabase = 'தரவுத்தள பிழை. மீண்டும் முயற்சிக்கவும்.';
+  static const String errorDatabaseInit = 'தரவுத்தளத்தை துவக்க முடியவில்லை';
 }

--- a/lib/core/utils/phone_hasher.dart
+++ b/lib/core/utils/phone_hasher.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+import '../exceptions/app_exception.dart';
+import '../logging/logger.dart';
+
+/// Utility for hashing phone numbers using HMAC-SHA256.
+///
+/// Phone numbers are never stored in plaintext. This class normalizes
+/// the input (strips country code, whitespace) and produces a
+/// deterministic hex-encoded hash.
+class PhoneHasher {
+  PhoneHasher._();
+
+  // TODO(phase-2.1): Move salt to --dart-define for production builds.
+  static const String _salt = 'NilamAI_2026_agri_phone_salt_v1';
+
+  /// Normalizes and hashes a phone number using HMAC-SHA256.
+  ///
+  /// Accepts formats: `9876543210`, `+919876543210`, `91 9876543210`.
+  /// Returns a 64-character hex string.
+  ///
+  /// Throws [DatabaseException] if the phone number is invalid.
+  static String hash(String phoneNumber) {
+    final normalized = _normalize(phoneNumber);
+    final hmac = Hmac(sha256, utf8.encode(_salt));
+    final digest = hmac.convert(utf8.encode(normalized));
+    AppLogger.debug('Phone number hashed successfully', 'PhoneHasher');
+    return digest.toString();
+  }
+
+  /// Strips whitespace, dashes, and the +91/91 country code prefix.
+  /// Validates that the result is exactly 10 digits.
+  static String _normalize(String phoneNumber) {
+    var cleaned = phoneNumber.replaceAll(RegExp(r'[\s\-()]'), '');
+
+    if (cleaned.startsWith('+91')) {
+      cleaned = cleaned.substring(3);
+    } else if (cleaned.startsWith('91') && cleaned.length == 12) {
+      cleaned = cleaned.substring(2);
+    }
+
+    if (cleaned.length != 10 || !RegExp(r'^\d{10}$').hasMatch(cleaned)) {
+      throw const DatabaseException(
+        message: 'Invalid phone number: must be 10 digits',
+      );
+    }
+
+    return cleaned;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,12 +3,26 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'config/routes.dart';
 import 'config/theme.dart';
+import 'core/logging/logger.dart';
+import 'providers/database_providers.dart';
+import 'services/database/database_service.dart';
 
-void main() {
+void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  final dbService = DatabaseService.create();
+  try {
+    await dbService.initialize();
+  } catch (e) {
+    AppLogger.error('Database initialization failed', 'main', e);
+  }
+
   runApp(
-    const ProviderScope(
-      child: NilamAIApp(),
+    ProviderScope(
+      overrides: [
+        databaseServiceProvider.overrideWithValue(dbService),
+      ],
+      child: const NilamAIApp(),
     ),
   );
 }

--- a/lib/providers/database_providers.dart
+++ b/lib/providers/database_providers.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/database/database_service.dart';
+import '../services/database/daos/user_profile_dao.dart';
+import '../services/database/daos/query_history_dao.dart';
+
+/// Provides the initialized [DatabaseService].
+///
+/// Must be overridden in [ProviderScope] with an initialized instance:
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     databaseServiceProvider.overrideWithValue(dbService),
+///   ],
+///   child: const NilamAIApp(),
+/// )
+/// ```
+final databaseServiceProvider = Provider<DatabaseService>((ref) {
+  throw UnimplementedError(
+    'databaseServiceProvider must be overridden with an initialized DatabaseService',
+  );
+});
+
+/// Convenience provider for [UserProfileDao].
+final userProfileDaoProvider = Provider<UserProfileDao>((ref) {
+  return ref.watch(databaseServiceProvider).userProfileDao;
+});
+
+/// Convenience provider for [QueryHistoryDao].
+final queryHistoryDaoProvider = Provider<QueryHistoryDao>((ref) {
+  return ref.watch(databaseServiceProvider).queryHistoryDao;
+});

--- a/lib/services/database/daos/query_history_dao.dart
+++ b/lib/services/database/daos/query_history_dao.dart
@@ -1,0 +1,201 @@
+import 'package:sqflite/sqflite.dart' hide DatabaseException;
+
+import '../../../core/exceptions/app_exception.dart';
+import '../../../core/logging/logger.dart';
+import '../database_constants.dart';
+import '../models/query_history.dart';
+
+/// Data Access Object for [QueryHistory] CRUD and search operations.
+class QueryHistoryDao {
+  const QueryHistoryDao(this._database);
+
+  final Database _database;
+
+  static const _tag = 'QueryHistoryDao';
+  static const _table = DatabaseConstants.tableQueryHistory;
+
+  /// Insert a new query history record.
+  Future<void> insert(QueryHistory query) async {
+    try {
+      await _database.insert(
+        _table,
+        query.toMap(),
+        conflictAlgorithm: ConflictAlgorithm.abort,
+      );
+      AppLogger.debug('Inserted query: ${query.id}', _tag);
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to insert query', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to insert query history',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Get a query by ID. Returns `null` if not found.
+  Future<QueryHistory?> getById(String id) async {
+    try {
+      final rows = await _database.query(
+        _table,
+        where: 'id = ?',
+        whereArgs: [id],
+        limit: 1,
+      );
+      if (rows.isEmpty) return null;
+      return QueryHistory.fromMap(rows.first);
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to get query by ID', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to get query history',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Get all queries for a user, ordered by timestamp descending.
+  ///
+  /// Supports pagination via [limit] and [offset].
+  Future<List<QueryHistory>> getByUserId(
+    String userId, {
+    int limit = 50,
+    int offset = 0,
+  }) async {
+    try {
+      final rows = await _database.query(
+        _table,
+        where: 'user_id = ?',
+        whereArgs: [userId],
+        orderBy: 'timestamp DESC',
+        limit: limit,
+        offset: offset,
+      );
+      return rows.map(QueryHistory.fromMap).toList();
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to get queries by user', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to get query history for user',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Search queries by keyword in transcription or gemma_response.
+  ///
+  /// If [userId] is provided, results are scoped to that user.
+  Future<List<QueryHistory>> searchByKeyword(
+    String keyword, {
+    String? userId,
+    int limit = 50,
+  }) async {
+    try {
+      final pattern = '%$keyword%';
+      String where;
+      List<Object?> whereArgs;
+
+      if (userId != null) {
+        where =
+            'user_id = ? AND (transcription LIKE ? OR gemma_response LIKE ?)';
+        whereArgs = [userId, pattern, pattern];
+      } else {
+        where = 'transcription LIKE ? OR gemma_response LIKE ?';
+        whereArgs = [pattern, pattern];
+      }
+
+      final rows = await _database.query(
+        _table,
+        where: where,
+        whereArgs: whereArgs,
+        orderBy: 'timestamp DESC',
+        limit: limit,
+      );
+      return rows.map(QueryHistory.fromMap).toList();
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to search queries', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to search query history',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Update a query record (e.g., to add gemma_response after LLM completes).
+  Future<void> update(QueryHistory query) async {
+    try {
+      final count = await _database.update(
+        _table,
+        query.toMap(),
+        where: 'id = ?',
+        whereArgs: [query.id],
+      );
+      if (count == 0) {
+        throw const DatabaseException(message: 'Query history not found');
+      }
+      AppLogger.debug('Updated query: ${query.id}', _tag);
+    } on DatabaseException {
+      rethrow;
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to update query', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to update query history',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Delete a query by ID. Returns `true` if a row was deleted.
+  Future<bool> delete(String id) async {
+    try {
+      final count = await _database.delete(
+        _table,
+        where: 'id = ?',
+        whereArgs: [id],
+      );
+      AppLogger.debug('Deleted query: $id (count=$count)', _tag);
+      return count > 0;
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to delete query', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to delete query history',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Delete all queries for a user. Returns the number of rows deleted.
+  ///
+  /// Used for the "clear history" privacy control.
+  Future<int> deleteAllForUser(String userId) async {
+    try {
+      final count = await _database.delete(
+        _table,
+        where: 'user_id = ?',
+        whereArgs: [userId],
+      );
+      AppLogger.info('Cleared $count queries for user: $userId', _tag);
+      return count;
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to clear queries', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to clear query history',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Get the total count of queries for a user.
+  Future<int> countForUser(String userId) async {
+    try {
+      final result = await _database.rawQuery(
+        'SELECT COUNT(*) AS count FROM $_table WHERE user_id = ?',
+        [userId],
+      );
+      return Sqflite.firstIntValue(result) ?? 0;
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to count queries', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to count query history',
+        originalError: e,
+      );
+    }
+  }
+}

--- a/lib/services/database/daos/user_profile_dao.dart
+++ b/lib/services/database/daos/user_profile_dao.dart
@@ -1,0 +1,138 @@
+import 'package:sqflite/sqflite.dart' hide DatabaseException;
+
+import '../../../core/exceptions/app_exception.dart';
+import '../../../core/logging/logger.dart';
+import '../database_constants.dart';
+import '../models/user_profile.dart';
+
+/// Data Access Object for [UserProfile] CRUD operations.
+class UserProfileDao {
+  const UserProfileDao(this._database);
+
+  final Database _database;
+
+  static const _tag = 'UserProfileDao';
+  static const _table = DatabaseConstants.tableUserProfile;
+
+  /// Insert a new user profile.
+  ///
+  /// Throws [DatabaseException] if the phone number already exists.
+  Future<void> insert(UserProfile profile) async {
+    try {
+      await _database.insert(
+        _table,
+        profile.toMap(),
+        conflictAlgorithm: ConflictAlgorithm.abort,
+      );
+      AppLogger.debug('Inserted profile: ${profile.id}', _tag);
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to insert profile', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to insert user profile',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Get a user profile by ID. Returns `null` if not found.
+  Future<UserProfile?> getById(String id) async {
+    try {
+      final rows = await _database.query(
+        _table,
+        where: 'id = ?',
+        whereArgs: [id],
+        limit: 1,
+      );
+      if (rows.isEmpty) return null;
+      return UserProfile.fromMap(rows.first);
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to get profile by ID', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to get user profile',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Get a user profile by hashed phone number. Returns `null` if not found.
+  Future<UserProfile?> getByPhoneHash(String phoneHash) async {
+    try {
+      final rows = await _database.query(
+        _table,
+        where: 'phone_number = ?',
+        whereArgs: [phoneHash],
+        limit: 1,
+      );
+      if (rows.isEmpty) return null;
+      return UserProfile.fromMap(rows.first);
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to get profile by phone', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to get user profile by phone',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Get the current (first) user profile.
+  ///
+  /// For the single-user MVP, only one profile exists per installation.
+  Future<UserProfile?> getCurrent() async {
+    try {
+      final rows = await _database.query(_table, limit: 1);
+      if (rows.isEmpty) return null;
+      return UserProfile.fromMap(rows.first);
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to get current profile', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to get current user profile',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Update an existing user profile.
+  ///
+  /// Throws [DatabaseException] if the profile does not exist.
+  Future<void> update(UserProfile profile) async {
+    try {
+      final count = await _database.update(
+        _table,
+        profile.toMap(),
+        where: 'id = ?',
+        whereArgs: [profile.id],
+      );
+      if (count == 0) {
+        throw const DatabaseException(message: 'User profile not found');
+      }
+      AppLogger.debug('Updated profile: ${profile.id}', _tag);
+    } on DatabaseException {
+      rethrow;
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to update profile', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to update user profile',
+        originalError: e,
+      );
+    }
+  }
+
+  /// Delete a user profile by ID. Returns `true` if a row was deleted.
+  Future<bool> delete(String id) async {
+    try {
+      final count = await _database.delete(
+        _table,
+        where: 'id = ?',
+        whereArgs: [id],
+      );
+      AppLogger.debug('Deleted profile: $id (count=$count)', _tag);
+      return count > 0;
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to delete profile', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Failed to delete user profile',
+        originalError: e,
+      );
+    }
+  }
+}

--- a/lib/services/database/database_constants.dart
+++ b/lib/services/database/database_constants.dart
@@ -1,0 +1,52 @@
+/// Database schema constants, table names, and SQL DDL statements.
+class DatabaseConstants {
+  DatabaseConstants._();
+
+  static const String databaseName = 'nilam_ai.db';
+  static const int databaseVersion = 1;
+
+  // -- Table names --
+  static const String tableUserProfile = 'user_profile';
+  static const String tableQueryHistory = 'query_history';
+
+  // -- SQL: Create tables --
+
+  static const String createUserProfile = '''
+    CREATE TABLE $tableUserProfile (
+      id TEXT PRIMARY KEY,
+      phone_number TEXT NOT NULL UNIQUE,
+      name TEXT,
+      village TEXT,
+      district TEXT,
+      primary_crop TEXT,
+      language TEXT DEFAULT 'ta-IN',
+      tts_speed REAL DEFAULT 1.0,
+      notifications_enabled INTEGER DEFAULT 1,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  ''';
+
+  static const String createQueryHistory = '''
+    CREATE TABLE $tableQueryHistory (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      audio_file_path TEXT,
+      transcription TEXT NOT NULL,
+      transcription_confidence REAL,
+      gemma_prompt TEXT,
+      gemma_response TEXT,
+      gemma_latency_ms INTEGER,
+      user_rating TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES $tableUserProfile(id)
+    )
+  ''';
+
+  // -- SQL: Create indexes --
+
+  static const String createIndexQueryUserDate =
+      'CREATE INDEX idx_query_user_date ON $tableQueryHistory(user_id, timestamp DESC)';
+}

--- a/lib/services/database/database_service.dart
+++ b/lib/services/database/database_service.dart
@@ -1,0 +1,107 @@
+import 'package:sqflite/sqflite.dart' hide DatabaseException;
+
+import '../../core/exceptions/app_exception.dart';
+import '../../core/logging/logger.dart';
+import 'database_constants.dart';
+import 'daos/user_profile_dao.dart';
+import 'daos/query_history_dao.dart';
+
+/// Central database service that manages the SQLite connection,
+/// schema creation, migrations, and DAO access.
+///
+/// Created via [DatabaseService.create] and initialized with [initialize].
+/// Typically used as a singleton through Riverpod.
+class DatabaseService {
+  DatabaseService._internal();
+
+  /// Create a new [DatabaseService] instance.
+  ///
+  /// Call [initialize] before accessing DAOs.
+  static DatabaseService create() => DatabaseService._internal();
+
+  Database? _database;
+  UserProfileDao? _userProfileDao;
+  QueryHistoryDao? _queryHistoryDao;
+
+  static const _tag = 'DatabaseService';
+
+  /// Whether the database has been initialized.
+  bool get isInitialized => _database != null;
+
+  /// Access the [UserProfileDao]. Asserts that [initialize] was called.
+  UserProfileDao get userProfileDao {
+    assert(isInitialized, 'DatabaseService not initialized. Call initialize() first.');
+    return _userProfileDao!;
+  }
+
+  /// Access the [QueryHistoryDao]. Asserts that [initialize] was called.
+  QueryHistoryDao get queryHistoryDao {
+    assert(isInitialized, 'DatabaseService not initialized. Call initialize() first.');
+    return _queryHistoryDao!;
+  }
+
+  /// Initialize the database connection and create tables.
+  ///
+  /// Pass [path] to override the default database path.
+  /// Use `':memory:'` or an in-memory path for testing.
+  Future<void> initialize({String? path}) async {
+    if (_database != null) {
+      AppLogger.warning('Database already initialized', _tag);
+      return;
+    }
+
+    try {
+      final dbPath = path ??
+          '${await getDatabasesPath()}/${DatabaseConstants.databaseName}';
+
+      _database = await openDatabase(
+        dbPath,
+        version: DatabaseConstants.databaseVersion,
+        onCreate: _onCreate,
+        onUpgrade: _onUpgrade,
+        onConfigure: _onConfigure,
+      );
+
+      _userProfileDao = UserProfileDao(_database!);
+      _queryHistoryDao = QueryHistoryDao(_database!);
+
+      AppLogger.info('Database initialized at: $dbPath', _tag);
+    } catch (e, stackTrace) {
+      AppLogger.error('Failed to initialize database', _tag, e, stackTrace);
+      throw DatabaseException(
+        message: 'Database initialization failed',
+        originalError: e,
+      );
+    }
+  }
+
+  Future<void> _onConfigure(Database db) async {
+    await db.execute('PRAGMA foreign_keys = ON');
+  }
+
+  Future<void> _onCreate(Database db, int version) async {
+    AppLogger.info('Creating database schema v$version', _tag);
+    await db.execute(DatabaseConstants.createUserProfile);
+    await db.execute(DatabaseConstants.createQueryHistory);
+    await db.execute(DatabaseConstants.createIndexQueryUserDate);
+  }
+
+  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    AppLogger.info(
+      'Upgrading database from v$oldVersion to v$newVersion',
+      _tag,
+    );
+    // Sequential migration pattern:
+    // if (oldVersion < 2) { await _migrateV1ToV2(db); }
+    // if (oldVersion < 3) { await _migrateV2ToV3(db); }
+  }
+
+  /// Close the database connection and release resources.
+  Future<void> close() async {
+    await _database?.close();
+    _database = null;
+    _userProfileDao = null;
+    _queryHistoryDao = null;
+    AppLogger.info('Database closed', _tag);
+  }
+}

--- a/lib/services/database/models/query_history.dart
+++ b/lib/services/database/models/query_history.dart
@@ -1,0 +1,140 @@
+/// Immutable model representing a query history record stored in SQLite.
+///
+/// Each record captures a farmer's voice query, its transcription,
+/// and the Gemma LLM response with associated metadata.
+class QueryHistory {
+  const QueryHistory({
+    required this.id,
+    required this.userId,
+    required this.timestamp,
+    this.audioFilePath,
+    required this.transcription,
+    this.transcriptionConfidence,
+    this.gemmaPrompt,
+    this.gemmaResponse,
+    this.gemmaLatencyMs,
+    this.userRating,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String userId;
+  final DateTime timestamp;
+  final String? audioFilePath;
+  final String transcription;
+  final double? transcriptionConfidence;
+  final String? gemmaPrompt;
+  final String? gemmaResponse;
+  final int? gemmaLatencyMs;
+  final String? userRating;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory QueryHistory.fromMap(Map<String, dynamic> map) {
+    return QueryHistory(
+      id: map['id'] as String,
+      userId: map['user_id'] as String,
+      timestamp:
+          DateTime.fromMillisecondsSinceEpoch(map['timestamp'] as int),
+      audioFilePath: map['audio_file_path'] as String?,
+      transcription: map['transcription'] as String,
+      transcriptionConfidence:
+          (map['transcription_confidence'] as num?)?.toDouble(),
+      gemmaPrompt: map['gemma_prompt'] as String?,
+      gemmaResponse: map['gemma_response'] as String?,
+      gemmaLatencyMs: map['gemma_latency_ms'] as int?,
+      userRating: map['user_rating'] as String?,
+      createdAt:
+          DateTime.fromMillisecondsSinceEpoch(map['created_at'] as int),
+      updatedAt:
+          DateTime.fromMillisecondsSinceEpoch(map['updated_at'] as int),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'user_id': userId,
+      'timestamp': timestamp.millisecondsSinceEpoch,
+      'audio_file_path': audioFilePath,
+      'transcription': transcription,
+      'transcription_confidence': transcriptionConfidence,
+      'gemma_prompt': gemmaPrompt,
+      'gemma_response': gemmaResponse,
+      'gemma_latency_ms': gemmaLatencyMs,
+      'user_rating': userRating,
+      'created_at': createdAt.millisecondsSinceEpoch,
+      'updated_at': updatedAt.millisecondsSinceEpoch,
+    };
+  }
+
+  QueryHistory copyWith({
+    String? id,
+    String? userId,
+    DateTime? timestamp,
+    String? audioFilePath,
+    String? transcription,
+    double? transcriptionConfidence,
+    String? gemmaPrompt,
+    String? gemmaResponse,
+    int? gemmaLatencyMs,
+    String? userRating,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return QueryHistory(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      timestamp: timestamp ?? this.timestamp,
+      audioFilePath: audioFilePath ?? this.audioFilePath,
+      transcription: transcription ?? this.transcription,
+      transcriptionConfidence:
+          transcriptionConfidence ?? this.transcriptionConfidence,
+      gemmaPrompt: gemmaPrompt ?? this.gemmaPrompt,
+      gemmaResponse: gemmaResponse ?? this.gemmaResponse,
+      gemmaLatencyMs: gemmaLatencyMs ?? this.gemmaLatencyMs,
+      userRating: userRating ?? this.userRating,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is QueryHistory &&
+        other.id == id &&
+        other.userId == userId &&
+        other.timestamp == timestamp &&
+        other.audioFilePath == audioFilePath &&
+        other.transcription == transcription &&
+        other.transcriptionConfidence == transcriptionConfidence &&
+        other.gemmaPrompt == gemmaPrompt &&
+        other.gemmaResponse == gemmaResponse &&
+        other.gemmaLatencyMs == gemmaLatencyMs &&
+        other.userRating == userRating &&
+        other.createdAt == createdAt &&
+        other.updatedAt == updatedAt;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        userId,
+        timestamp,
+        audioFilePath,
+        transcription,
+        transcriptionConfidence,
+        gemmaPrompt,
+        gemmaResponse,
+        gemmaLatencyMs,
+        userRating,
+        createdAt,
+        updatedAt,
+      );
+
+  @override
+  String toString() =>
+      'QueryHistory(id: $id, userId: $userId, timestamp: $timestamp)';
+}

--- a/lib/services/database/models/user_profile.dart
+++ b/lib/services/database/models/user_profile.dart
@@ -1,0 +1,126 @@
+/// Immutable model representing a user profile stored in SQLite.
+///
+/// [phoneNumber] is always a SHA-256 hash — never plaintext.
+/// Dates are stored as millisecondsSinceEpoch in the database.
+class UserProfile {
+  const UserProfile({
+    required this.id,
+    required this.phoneNumber,
+    this.name,
+    this.village,
+    this.district,
+    this.primaryCrop,
+    this.language = 'ta-IN',
+    this.ttsSpeed = 1.0,
+    this.notificationsEnabled = true,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String phoneNumber;
+  final String? name;
+  final String? village;
+  final String? district;
+  final String? primaryCrop;
+  final String language;
+  final double ttsSpeed;
+  final bool notificationsEnabled;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory UserProfile.fromMap(Map<String, dynamic> map) {
+    return UserProfile(
+      id: map['id'] as String,
+      phoneNumber: map['phone_number'] as String,
+      name: map['name'] as String?,
+      village: map['village'] as String?,
+      district: map['district'] as String?,
+      primaryCrop: map['primary_crop'] as String?,
+      language: (map['language'] as String?) ?? 'ta-IN',
+      ttsSpeed: (map['tts_speed'] as num?)?.toDouble() ?? 1.0,
+      notificationsEnabled: (map['notifications_enabled'] as int?) != 0,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(map['created_at'] as int),
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(map['updated_at'] as int),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'phone_number': phoneNumber,
+      'name': name,
+      'village': village,
+      'district': district,
+      'primary_crop': primaryCrop,
+      'language': language,
+      'tts_speed': ttsSpeed,
+      'notifications_enabled': notificationsEnabled ? 1 : 0,
+      'created_at': createdAt.millisecondsSinceEpoch,
+      'updated_at': updatedAt.millisecondsSinceEpoch,
+    };
+  }
+
+  UserProfile copyWith({
+    String? id,
+    String? phoneNumber,
+    String? name,
+    String? village,
+    String? district,
+    String? primaryCrop,
+    String? language,
+    double? ttsSpeed,
+    bool? notificationsEnabled,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return UserProfile(
+      id: id ?? this.id,
+      phoneNumber: phoneNumber ?? this.phoneNumber,
+      name: name ?? this.name,
+      village: village ?? this.village,
+      district: district ?? this.district,
+      primaryCrop: primaryCrop ?? this.primaryCrop,
+      language: language ?? this.language,
+      ttsSpeed: ttsSpeed ?? this.ttsSpeed,
+      notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is UserProfile &&
+        other.id == id &&
+        other.phoneNumber == phoneNumber &&
+        other.name == name &&
+        other.village == village &&
+        other.district == district &&
+        other.primaryCrop == primaryCrop &&
+        other.language == language &&
+        other.ttsSpeed == ttsSpeed &&
+        other.notificationsEnabled == notificationsEnabled &&
+        other.createdAt == createdAt &&
+        other.updatedAt == updatedAt;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        phoneNumber,
+        name,
+        village,
+        district,
+        primaryCrop,
+        language,
+        ttsSpeed,
+        notificationsEnabled,
+        createdAt,
+        updatedAt,
+      );
+
+  @override
+  String toString() => 'UserProfile(id: $id, district: $district)';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,11 +19,13 @@ dependencies:
   intl: ^0.19.0
   uuid: ^4.5.1
   shared_preferences: ^2.2.3
+  crypto: ^3.0.7
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  sqflite_common_ffi: ^2.3.4+5
 
 flutter:
   uses-material-design: true

--- a/test/core/utils/phone_hasher_test.dart
+++ b/test/core/utils/phone_hasher_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+import 'package:nilam_ai/core/utils/phone_hasher.dart';
+
+void main() {
+  group('PhoneHasher', () {
+    test('produces deterministic hash for same input', () {
+      final hash1 = PhoneHasher.hash('9876543210');
+      final hash2 = PhoneHasher.hash('9876543210');
+      expect(hash1, equals(hash2));
+    });
+
+    test('produces different hashes for different inputs', () {
+      final hash1 = PhoneHasher.hash('9876543210');
+      final hash2 = PhoneHasher.hash('9876543211');
+      expect(hash1, isNot(equals(hash2)));
+    });
+
+    test('produces 64-character hex string (SHA-256)', () {
+      final hash = PhoneHasher.hash('9876543210');
+      expect(hash.length, equals(64));
+      expect(hash, matches(RegExp(r'^[0-9a-f]{64}$')));
+    });
+
+    test('normalizes +91 prefix', () {
+      final withPrefix = PhoneHasher.hash('+919876543210');
+      final withoutPrefix = PhoneHasher.hash('9876543210');
+      expect(withPrefix, equals(withoutPrefix));
+    });
+
+    test('normalizes 91 prefix (12 digits)', () {
+      final withPrefix = PhoneHasher.hash('919876543210');
+      final withoutPrefix = PhoneHasher.hash('9876543210');
+      expect(withPrefix, equals(withoutPrefix));
+    });
+
+    test('strips whitespace and dashes', () {
+      final clean = PhoneHasher.hash('9876543210');
+      final withSpaces = PhoneHasher.hash('987 654 3210');
+      final withDashes = PhoneHasher.hash('987-654-3210');
+      expect(withSpaces, equals(clean));
+      expect(withDashes, equals(clean));
+    });
+
+    test('throws DatabaseException for too few digits', () {
+      expect(
+        () => PhoneHasher.hash('12345'),
+        throwsA(isA<DatabaseException>()),
+      );
+    });
+
+    test('throws DatabaseException for too many digits', () {
+      expect(
+        () => PhoneHasher.hash('12345678901234'),
+        throwsA(isA<DatabaseException>()),
+      );
+    });
+
+    test('throws DatabaseException for non-numeric input', () {
+      expect(
+        () => PhoneHasher.hash('abcdefghij'),
+        throwsA(isA<DatabaseException>()),
+      );
+    });
+
+    test('throws DatabaseException for empty input', () {
+      expect(
+        () => PhoneHasher.hash(''),
+        throwsA(isA<DatabaseException>()),
+      );
+    });
+  });
+}

--- a/test/providers/database_providers_test.dart
+++ b/test/providers/database_providers_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:nilam_ai/providers/database_providers.dart';
+import 'package:nilam_ai/services/database/database_service.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  group('Database Providers', () {
+    test('databaseServiceProvider throws when not overridden', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        () => container.read(databaseServiceProvider),
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+
+    test('databaseServiceProvider works with override', () async {
+      final dbService = DatabaseService.create();
+      await dbService.initialize(path: inMemoryDatabasePath);
+
+      final container = ProviderContainer(
+        overrides: [
+          databaseServiceProvider.overrideWithValue(dbService),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await dbService.close();
+      });
+
+      expect(container.read(databaseServiceProvider), equals(dbService));
+    });
+
+    test('userProfileDaoProvider returns DAO from service', () async {
+      final dbService = DatabaseService.create();
+      await dbService.initialize(path: inMemoryDatabasePath);
+
+      final container = ProviderContainer(
+        overrides: [
+          databaseServiceProvider.overrideWithValue(dbService),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await dbService.close();
+      });
+
+      final dao = container.read(userProfileDaoProvider);
+      expect(dao, isNotNull);
+    });
+
+    test('queryHistoryDaoProvider returns DAO from service', () async {
+      final dbService = DatabaseService.create();
+      await dbService.initialize(path: inMemoryDatabasePath);
+
+      final container = ProviderContainer(
+        overrides: [
+          databaseServiceProvider.overrideWithValue(dbService),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await dbService.close();
+      });
+
+      final dao = container.read(queryHistoryDaoProvider);
+      expect(dao, isNotNull);
+    });
+  });
+}

--- a/test/services/database/daos/query_history_dao_test.dart
+++ b/test/services/database/daos/query_history_dao_test.dart
@@ -1,0 +1,225 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:nilam_ai/services/database/database_service.dart';
+import 'package:nilam_ai/services/database/daos/user_profile_dao.dart';
+import 'package:nilam_ai/services/database/daos/query_history_dao.dart';
+import 'package:nilam_ai/services/database/models/user_profile.dart';
+import 'package:nilam_ai/services/database/models/query_history.dart';
+
+const _userId = 'test-user';
+
+UserProfile _makeUser() {
+  final now = DateTime.now();
+  return UserProfile(
+    id: _userId,
+    phoneNumber: 'hashed-phone',
+    name: 'Test Farmer',
+    district: 'Thanjavur',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+QueryHistory _makeQuery({
+  required String id,
+  String userId = _userId,
+  String transcription = 'நெல் விலை என்ன?',
+  String? gemmaResponse,
+  DateTime? timestamp,
+}) {
+  final now = timestamp ?? DateTime.now();
+  return QueryHistory(
+    id: id,
+    userId: userId,
+    timestamp: now,
+    transcription: transcription,
+    gemmaResponse: gemmaResponse,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late DatabaseService service;
+  late UserProfileDao userDao;
+  late QueryHistoryDao dao;
+
+  setUp(() async {
+    service = DatabaseService.create();
+    await service.initialize(path: inMemoryDatabasePath);
+    userDao = service.userProfileDao;
+    dao = service.queryHistoryDao;
+
+    // Insert a user for FK constraint.
+    await userDao.insert(_makeUser());
+  });
+
+  tearDown(() async {
+    await service.close();
+  });
+
+  group('QueryHistoryDao', () {
+    test('insert and retrieve by ID', () async {
+      final query = _makeQuery(id: 'q1');
+      await dao.insert(query);
+
+      final retrieved = await dao.getById('q1');
+      expect(retrieved, isNotNull);
+      expect(retrieved!.id, equals('q1'));
+      expect(retrieved.transcription, equals('நெல் விலை என்ன?'));
+    });
+
+    test('getById returns null for nonexistent', () async {
+      final result = await dao.getById('no-such-id');
+      expect(result, isNull);
+    });
+
+    test('getByUserId returns ordered by timestamp DESC', () async {
+      final t1 = DateTime(2026, 4, 17, 8, 0);
+      final t2 = DateTime(2026, 4, 17, 9, 0);
+      final t3 = DateTime(2026, 4, 17, 10, 0);
+
+      await dao.insert(_makeQuery(id: 'q1', timestamp: t1));
+      await dao.insert(_makeQuery(id: 'q2', timestamp: t3));
+      await dao.insert(_makeQuery(id: 'q3', timestamp: t2));
+
+      final results = await dao.getByUserId(_userId);
+      expect(results.length, equals(3));
+      expect(results[0].id, equals('q2')); // t3 (latest)
+      expect(results[1].id, equals('q3')); // t2
+      expect(results[2].id, equals('q1')); // t1 (oldest)
+    });
+
+    test('getByUserId supports pagination', () async {
+      for (var i = 0; i < 10; i++) {
+        await dao.insert(_makeQuery(
+          id: 'q$i',
+          timestamp: DateTime(2026, 4, 17, i),
+        ));
+      }
+
+      final page1 = await dao.getByUserId(_userId, limit: 3, offset: 0);
+      final page2 = await dao.getByUserId(_userId, limit: 3, offset: 3);
+      expect(page1.length, equals(3));
+      expect(page2.length, equals(3));
+      expect(page1.first.id, isNot(equals(page2.first.id)));
+    });
+
+    test('searchByKeyword finds matches in transcription', () async {
+      await dao.insert(_makeQuery(id: 'q1', transcription: 'நெல் விலை'));
+      await dao.insert(_makeQuery(id: 'q2', transcription: 'தக்காளி விலை'));
+      await dao.insert(_makeQuery(id: 'q3', transcription: 'வானிலை'));
+
+      final results = await dao.searchByKeyword('விலை');
+      expect(results.length, equals(2));
+    });
+
+    test('searchByKeyword finds matches in gemma_response', () async {
+      await dao.insert(_makeQuery(
+        id: 'q1',
+        transcription: 'test',
+        gemmaResponse: 'Rice price is ₹2000',
+      ));
+      await dao.insert(_makeQuery(
+        id: 'q2',
+        transcription: 'test2',
+        gemmaResponse: 'Tomato advice',
+      ));
+
+      final results = await dao.searchByKeyword('price');
+      expect(results.length, equals(1));
+      expect(results.first.id, equals('q1'));
+    });
+
+    test('searchByKeyword with userId scopes results', () async {
+      // Create second user.
+      final now = DateTime.now();
+      await userDao.insert(UserProfile(
+        id: 'user-2',
+        phoneNumber: 'hash-2',
+        createdAt: now,
+        updatedAt: now,
+      ));
+
+      await dao.insert(_makeQuery(id: 'q1', transcription: 'நெல் விலை'));
+      await dao.insert(_makeQuery(
+        id: 'q2',
+        userId: 'user-2',
+        transcription: 'நெல் விலை',
+      ));
+
+      final results = await dao.searchByKeyword('நெல்', userId: _userId);
+      expect(results.length, equals(1));
+      expect(results.first.userId, equals(_userId));
+    });
+
+    test('update modifies fields', () async {
+      await dao.insert(_makeQuery(id: 'q1'));
+      final original = (await dao.getById('q1'))!;
+
+      final updated = original.copyWith(
+        gemmaResponse: 'New response',
+        updatedAt: DateTime.now(),
+      );
+      await dao.update(updated);
+
+      final retrieved = await dao.getById('q1');
+      expect(retrieved!.gemmaResponse, equals('New response'));
+    });
+
+    test('delete removes record', () async {
+      await dao.insert(_makeQuery(id: 'q1'));
+      final deleted = await dao.delete('q1');
+      expect(deleted, isTrue);
+      expect(await dao.getById('q1'), isNull);
+    });
+
+    test('delete returns false for nonexistent', () async {
+      final deleted = await dao.delete('no-such-id');
+      expect(deleted, isFalse);
+    });
+
+    test('deleteAllForUser removes all and returns count', () async {
+      await dao.insert(_makeQuery(id: 'q1'));
+      await dao.insert(_makeQuery(id: 'q2'));
+      await dao.insert(_makeQuery(id: 'q3'));
+
+      final count = await dao.deleteAllForUser(_userId);
+      expect(count, equals(3));
+
+      final remaining = await dao.getByUserId(_userId);
+      expect(remaining, isEmpty);
+    });
+
+    test('countForUser returns correct count', () async {
+      expect(await dao.countForUser(_userId), equals(0));
+
+      await dao.insert(_makeQuery(id: 'q1'));
+      await dao.insert(_makeQuery(id: 'q2'));
+      expect(await dao.countForUser(_userId), equals(2));
+    });
+
+    test('500-record search completes within 500ms', () async {
+      // Insert 500 records.
+      for (var i = 0; i < 500; i++) {
+        await dao.insert(_makeQuery(
+          id: 'perf-$i',
+          transcription: 'Query number $i about rice paddy cultivation',
+          timestamp: DateTime(2026, 1, 1).add(Duration(hours: i)),
+        ));
+      }
+
+      final stopwatch = Stopwatch()..start();
+      final results = await dao.searchByKeyword('rice', limit: 500);
+      stopwatch.stop();
+
+      expect(results.length, equals(500));
+      expect(stopwatch.elapsedMilliseconds, lessThan(500));
+    });
+  });
+}

--- a/test/services/database/daos/user_profile_dao_test.dart
+++ b/test/services/database/daos/user_profile_dao_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart' hide DatabaseException;
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+import 'package:nilam_ai/services/database/database_service.dart';
+import 'package:nilam_ai/services/database/daos/user_profile_dao.dart';
+import 'package:nilam_ai/services/database/models/user_profile.dart';
+
+UserProfile _makeProfile({
+  String id = 'user-1',
+  String phoneNumber = 'hashed-phone-1',
+  String? name = 'Test Farmer',
+  String? district = 'Thanjavur',
+}) {
+  final now = DateTime.now();
+  return UserProfile(
+    id: id,
+    phoneNumber: phoneNumber,
+    name: name,
+    village: 'TestVillage',
+    district: district,
+    primaryCrop: 'rice',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late DatabaseService service;
+  late UserProfileDao dao;
+
+  setUp(() async {
+    service = DatabaseService.create();
+    await service.initialize(path: inMemoryDatabasePath);
+    dao = service.userProfileDao;
+  });
+
+  tearDown(() async {
+    await service.close();
+  });
+
+  group('UserProfileDao', () {
+    test('insert and retrieve by ID', () async {
+      final profile = _makeProfile();
+      await dao.insert(profile);
+
+      final retrieved = await dao.getById('user-1');
+      expect(retrieved, isNotNull);
+      expect(retrieved!.id, equals('user-1'));
+      expect(retrieved.name, equals('Test Farmer'));
+    });
+
+    test('insert duplicate phone number throws DatabaseException', () async {
+      await dao.insert(_makeProfile(id: 'u1', phoneNumber: 'same-hash'));
+      expect(
+        () => dao.insert(_makeProfile(id: 'u2', phoneNumber: 'same-hash')),
+        throwsA(isA<DatabaseException>()),
+      );
+    });
+
+    test('getByPhoneHash returns correct profile', () async {
+      await dao.insert(_makeProfile(phoneNumber: 'unique-hash'));
+      final result = await dao.getByPhoneHash('unique-hash');
+      expect(result, isNotNull);
+      expect(result!.phoneNumber, equals('unique-hash'));
+    });
+
+    test('getByPhoneHash returns null for nonexistent', () async {
+      final result = await dao.getByPhoneHash('no-such-hash');
+      expect(result, isNull);
+    });
+
+    test('getCurrent returns first profile', () async {
+      await dao.insert(_makeProfile(id: 'u1', phoneNumber: 'hash-1'));
+      final result = await dao.getCurrent();
+      expect(result, isNotNull);
+      expect(result!.id, equals('u1'));
+    });
+
+    test('getCurrent returns null when empty', () async {
+      final result = await dao.getCurrent();
+      expect(result, isNull);
+    });
+
+    test('update modifies fields', () async {
+      final profile = _makeProfile();
+      await dao.insert(profile);
+
+      final updated = profile.copyWith(
+        name: 'Updated Name',
+        updatedAt: DateTime.now(),
+      );
+      await dao.update(updated);
+
+      final retrieved = await dao.getById('user-1');
+      expect(retrieved!.name, equals('Updated Name'));
+    });
+
+    test('update throws for nonexistent profile', () async {
+      final profile = _makeProfile(id: 'no-such-id');
+      expect(
+        () => dao.update(profile),
+        throwsA(isA<DatabaseException>()),
+      );
+    });
+
+    test('delete removes record', () async {
+      await dao.insert(_makeProfile());
+      final deleted = await dao.delete('user-1');
+      expect(deleted, isTrue);
+
+      final retrieved = await dao.getById('user-1');
+      expect(retrieved, isNull);
+    });
+
+    test('delete returns false for nonexistent', () async {
+      final deleted = await dao.delete('no-such-id');
+      expect(deleted, isFalse);
+    });
+
+    test('getById returns null for nonexistent', () async {
+      final result = await dao.getById('no-such-id');
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/services/database/database_service_test.dart
+++ b/test/services/database/database_service_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:nilam_ai/services/database/database_service.dart';
+import 'package:nilam_ai/services/database/models/query_history.dart';
+
+QueryHistory _makeQuery({required String id, required String userId}) {
+  final now = DateTime.now();
+  return QueryHistory(
+    id: id,
+    userId: userId,
+    timestamp: now,
+    transcription: 'test transcription',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late DatabaseService service;
+
+  setUp(() {
+    service = DatabaseService.create();
+  });
+
+  tearDown(() async {
+    if (service.isInitialized) {
+      await service.close();
+    }
+  });
+
+  group('DatabaseService', () {
+    test('initialize creates database and tables', () async {
+      await service.initialize(path: inMemoryDatabasePath);
+      expect(service.isInitialized, isTrue);
+    });
+
+    test('userProfileDao is accessible after initialize', () async {
+      await service.initialize(path: inMemoryDatabasePath);
+      expect(service.userProfileDao, isNotNull);
+    });
+
+    test('queryHistoryDao is accessible after initialize', () async {
+      await service.initialize(path: inMemoryDatabasePath);
+      expect(service.queryHistoryDao, isNotNull);
+    });
+
+    test('double initialize is idempotent', () async {
+      await service.initialize(path: inMemoryDatabasePath);
+      await service.initialize(path: inMemoryDatabasePath);
+      expect(service.isInitialized, isTrue);
+    });
+
+    test('close sets database to null', () async {
+      await service.initialize(path: inMemoryDatabasePath);
+      await service.close();
+      expect(service.isInitialized, isFalse);
+    });
+
+    test('foreign keys are enabled', () async {
+      await service.initialize(path: inMemoryDatabasePath);
+
+      final dao = service.queryHistoryDao;
+      expect(
+        () => dao.insert(_makeQuery(id: 'q1', userId: 'nonexistent-user')),
+        throwsA(anything),
+      );
+    });
+  });
+}

--- a/test/services/database/models/query_history_test.dart
+++ b/test/services/database/models/query_history_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/services/database/models/query_history.dart';
+
+void main() {
+  final now = DateTime(2026, 4, 17, 10, 0);
+
+  QueryHistory createQuery({
+    String id = 'query-uuid',
+    String? gemmaResponse,
+    double? transcriptionConfidence,
+  }) {
+    return QueryHistory(
+      id: id,
+      userId: 'user-uuid',
+      timestamp: now,
+      audioFilePath: '/audio/test.wav',
+      transcription: 'நெல் விலை என்ன?',
+      transcriptionConfidence: transcriptionConfidence,
+      gemmaPrompt: 'What is the rice price?',
+      gemmaResponse: gemmaResponse,
+      gemmaLatencyMs: 350,
+      userRating: 'helpful',
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  group('QueryHistory', () {
+    test('fromMap/toMap round-trips correctly', () {
+      final original = createQuery(gemmaResponse: 'Rice price is ₹2000/quintal');
+      final map = original.toMap();
+      final restored = QueryHistory.fromMap(map);
+      expect(restored, equals(original));
+    });
+
+    test('toMap stores DateTime as millisecondsSinceEpoch', () {
+      final query = createQuery();
+      final map = query.toMap();
+      expect(map['timestamp'], equals(now.millisecondsSinceEpoch));
+      expect(map['created_at'], equals(now.millisecondsSinceEpoch));
+    });
+
+    test('nullable fields survive round-trip as null', () {
+      final query = QueryHistory(
+        id: 'q-null',
+        userId: 'user-uuid',
+        timestamp: now,
+        transcription: 'test',
+        createdAt: now,
+        updatedAt: now,
+      );
+      final map = query.toMap();
+      final restored = QueryHistory.fromMap(map);
+
+      expect(restored.audioFilePath, isNull);
+      expect(restored.transcriptionConfidence, isNull);
+      expect(restored.gemmaPrompt, isNull);
+      expect(restored.gemmaResponse, isNull);
+      expect(restored.gemmaLatencyMs, isNull);
+      expect(restored.userRating, isNull);
+      expect(restored, equals(query));
+    });
+
+    test('copyWith produces new instance with changed field', () {
+      final original = createQuery();
+      final copy = original.copyWith(gemmaResponse: 'Updated response');
+      expect(copy.gemmaResponse, equals('Updated response'));
+      expect(copy.id, equals(original.id));
+    });
+
+    test('equality compares all fields', () {
+      final a = createQuery(gemmaResponse: 'response');
+      final b = createQuery(gemmaResponse: 'response');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('inequality when fields differ', () {
+      final a = createQuery(id: 'q-1');
+      final b = createQuery(id: 'q-2');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('toString includes id, userId, and timestamp', () {
+      final query = createQuery();
+      final str = query.toString();
+      expect(str, contains('query-uuid'));
+      expect(str, contains('user-uuid'));
+    });
+  });
+}

--- a/test/services/database/models/user_profile_test.dart
+++ b/test/services/database/models/user_profile_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/services/database/models/user_profile.dart';
+
+void main() {
+  final now = DateTime(2026, 4, 17, 10, 0);
+
+  UserProfile createProfile({
+    String id = 'test-uuid',
+    String phoneNumber = 'hashed-phone',
+    String? name = 'Test Farmer',
+    String? district = 'Thanjavur',
+    bool notificationsEnabled = true,
+  }) {
+    return UserProfile(
+      id: id,
+      phoneNumber: phoneNumber,
+      name: name,
+      village: 'TestVillage',
+      district: district,
+      primaryCrop: 'rice',
+      language: 'ta-IN',
+      ttsSpeed: 1.0,
+      notificationsEnabled: notificationsEnabled,
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  group('UserProfile', () {
+    test('fromMap/toMap round-trips correctly', () {
+      final original = createProfile();
+      final map = original.toMap();
+      final restored = UserProfile.fromMap(map);
+      expect(restored, equals(original));
+    });
+
+    test('toMap stores DateTime as millisecondsSinceEpoch', () {
+      final profile = createProfile();
+      final map = profile.toMap();
+      expect(map['created_at'], equals(now.millisecondsSinceEpoch));
+      expect(map['updated_at'], equals(now.millisecondsSinceEpoch));
+    });
+
+    test('toMap stores bool as int (1/0)', () {
+      final enabled = createProfile(notificationsEnabled: true);
+      final disabled = createProfile(notificationsEnabled: false);
+      expect(enabled.toMap()['notifications_enabled'], equals(1));
+      expect(disabled.toMap()['notifications_enabled'], equals(0));
+    });
+
+    test('fromMap converts int to bool for notifications', () {
+      final map = createProfile().toMap();
+
+      map['notifications_enabled'] = 1;
+      expect(UserProfile.fromMap(map).notificationsEnabled, isTrue);
+
+      map['notifications_enabled'] = 0;
+      expect(UserProfile.fromMap(map).notificationsEnabled, isFalse);
+    });
+
+    test('fromMap uses defaults for missing optional fields', () {
+      final map = {
+        'id': 'test-id',
+        'phone_number': 'hash',
+        'created_at': now.millisecondsSinceEpoch,
+        'updated_at': now.millisecondsSinceEpoch,
+      };
+      final profile = UserProfile.fromMap(map);
+      expect(profile.language, equals('ta-IN'));
+      expect(profile.ttsSpeed, equals(1.0));
+      expect(profile.notificationsEnabled, isTrue);
+      expect(profile.name, isNull);
+      expect(profile.village, isNull);
+      expect(profile.district, isNull);
+      expect(profile.primaryCrop, isNull);
+    });
+
+    test('copyWith produces new instance with changed field', () {
+      final original = createProfile();
+      final copy = original.copyWith(name: 'New Name');
+      expect(copy.name, equals('New Name'));
+      expect(copy.id, equals(original.id));
+      expect(copy, isNot(equals(original)));
+    });
+
+    test('equality compares all fields', () {
+      final a = createProfile();
+      final b = createProfile();
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('inequality when fields differ', () {
+      final a = createProfile(id: 'id-1');
+      final b = createProfile(id: 'id-2');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('toString does not expose phoneNumber', () {
+      final profile = createProfile();
+      final str = profile.toString();
+      expect(str, contains('id'));
+      expect(str, contains('district'));
+      expect(str, isNot(contains('hashed-phone')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **DatabaseService** with schema v1: `user_profile` and `query_history` tables, FK constraints, migration framework
- **UserProfileDao** / **QueryHistoryDao** with full CRUD, keyword search, pagination
- **PhoneHasher** utility (HMAC-SHA256, normalizes +91 prefix, never stores plaintext)
- **Riverpod providers** for DB service and DAOs, wired into `main.dart` via provider override
- **60 tests** across 7 files: models, DAOs, service, providers, and 500-record performance test
- Tamil error strings for database failures

## Deferred from scope
- SQLCipher encryption (Android 10+ has mandatory FBE; phone numbers are hashed)
- Mandi price table and user alert table (not needed until later phases)
- App salt via `--dart-define` (hardcoded for MVP)
- CSV data export for GDPR compliance

## Test plan
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 60/60 passed
- [x] `flutter run` on Moto G34 — DB initialized at `/data/user/0/com.nilamai.nilam_ai/databases/nilam_ai.db`
- [x] 500-record search completes in <500ms
