### PR TITLE
Phase 3: Audio recording with waveform visualization

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <application
         android:label="NilamAI"
         android:name="${applicationName}"

--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import '../core/constants/strings_tamil.dart';
+import '../screens/recording/recording_screen.dart';
 
 final GoRouter appRouter = GoRouter(
   initialLocation: '/',
@@ -11,6 +12,13 @@ final GoRouter appRouter = GoRouter(
       name: 'home',
       builder: (BuildContext context, GoRouterState state) {
         return const HomeScreen();
+      },
+    ),
+    GoRoute(
+      path: '/record',
+      name: 'record',
+      builder: (BuildContext context, GoRouterState state) {
+        return const RecordingScreen();
       },
     ),
   ],
@@ -53,6 +61,11 @@ class HomeScreen extends StatelessWidget {
             ),
           ],
         ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.push('/record'),
+        tooltip: TamilStrings.record,
+        child: const Icon(Icons.mic),
       ),
     );
   }

--- a/lib/core/constants/strings_tamil.dart
+++ b/lib/core/constants/strings_tamil.dart
@@ -34,10 +34,33 @@ class TamilStrings {
   static const String processing = 'செயலாக்குகிறது...';
   static const String ready = 'தயார்';
 
+  // -- Recording --
+  static const String recordingTitle = 'உங்கள் கேள்வியைக் கேளுங்கள்';
+  static const String tapToRecord = 'பதிவு செய்ய தட்டுங்கள்';
+  static const String recordingActive = 'பதி���ு செய்கிறது...';
+  static const String recordingComplete = 'பதி��ு முடிந்தது';
+
+  // -- Permissions --
+  static const String micPermissionNeeded = 'மைக்ரோஃபோன் அனுமதி தேவை';
+  static const String micPermissionExplain =
+      'உங்கள் குரலை பதிவு செய்ய மைக்ரோஃபோன் அனுமதி அவசியம்';
+  static const String openSettings = 'அமைப்புகளைத் திற';
+
+  // -- Quality warnings --
+  static const String warningTooQuiet =
+      'சத்தம் குறைவாக உள்ளது. சற்று சத்தமாகப் ப���சுங்கள்';
+  static const String warningClipping =
+      'சத்தம் அதிகமாக உள்��து. சற்று மெதுவாகப் பேசுங்கள்';
+
   // -- Errors --
   static const String errorGeneral = 'பிழை ஏற்பட்டது. மீண்டும் முயற்சிக்கவும்.';
   static const String errorMicrophone = 'மைக்ரோஃபோன் அணுக முடியவில்லை';
   static const String errorNetwork = 'இணைய இணைப்பு இல்லை';
+  static const String errorCodecUnsupported =
+      'இந்த சாதனத்தில் ஒலி பதிவு ஆதரிக்கப்படவில்லை';
+  static const String errorRecordingFailed =
+      'பதிவு தோல்வி. மீண்டும் முயற்சிக்கவும்';
+  static const String errorMaxDuration = 'அதிகபட்ச நேரம் எட்டப்பட்டத���';
   static const String errorDatabase = 'தரவுத்தள பிழை. மீண்டும் முயற்சிக்கவும்.';
   static const String errorDatabaseInit = 'தரவுத்தளத்தை துவக்க முடியவில்லை';
 }

--- a/lib/providers/audio_providers.dart
+++ b/lib/providers/audio_providers.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:record/record.dart';
+
+import '../core/constants/strings_tamil.dart';
+import '../core/logging/logger.dart';
+import '../services/audio/audio_constants.dart';
+import '../services/audio/audio_recording_service.dart';
+
+// -----------------------------------------------------------------------------
+// Sealed recording state
+// -----------------------------------------------------------------------------
+
+sealed class RecordingState {
+  const RecordingState();
+}
+
+class RecordingIdle extends RecordingState {
+  const RecordingIdle();
+}
+
+class RecordingActive extends RecordingState {
+  const RecordingActive({
+    required this.elapsed,
+    required this.amplitudes,
+  });
+
+  final Duration elapsed;
+  final List<double> amplitudes;
+}
+
+class RecordingComplete extends RecordingState {
+  const RecordingComplete({
+    required this.filePath,
+    required this.duration,
+    this.qualityWarning,
+  });
+
+  final String filePath;
+  final Duration duration;
+  final String? qualityWarning;
+}
+
+class RecordingError extends RecordingState {
+  const RecordingError({required this.message});
+
+  final String message;
+}
+
+// -----------------------------------------------------------------------------
+// Providers
+// -----------------------------------------------------------------------------
+
+final audioRecordingServiceProvider = Provider<AudioRecordingService>((ref) {
+  final service = AudioRecordingService(AudioRecorder());
+  ref.onDispose(() => service.dispose());
+  return service;
+});
+
+final recordingNotifierProvider =
+    NotifierProvider<RecordingNotifier, RecordingState>(
+  RecordingNotifier.new,
+);
+
+// -----------------------------------------------------------------------------
+// Notifier
+// -----------------------------------------------------------------------------
+
+class RecordingNotifier extends Notifier<RecordingState> {
+  static const _tag = 'RecordingNotifier';
+
+  Timer? _elapsedTimer;
+  StreamSubscription<Amplitude>? _amplitudeSub;
+  final List<double> _amplitudes = [];
+
+  @override
+  RecordingState build() => const RecordingIdle();
+
+  AudioRecordingService get _service =>
+      ref.read(audioRecordingServiceProvider);
+
+  // ---------------------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------------------
+
+  Future<void> startRecording() async {
+    try {
+      final granted = await _service.checkPermission();
+      if (!granted) {
+        state = const RecordingError(message: TamilStrings.micPermissionNeeded);
+        return;
+      }
+
+      await _service.startRecording();
+
+      _service.onAutoStop = _handleAutoStop;
+
+      _amplitudes.clear();
+      _amplitudeSub = _service.amplitudeStream.listen(_onAmplitude);
+
+      _elapsedTimer = Timer.periodic(
+        const Duration(seconds: 1),
+        (_) => _updateElapsed(),
+      );
+
+      state = RecordingActive(
+        elapsed: Duration.zero,
+        amplitudes: List.unmodifiable(_amplitudes),
+      );
+
+      AppLogger.info('Recording started', _tag);
+    } catch (e, st) {
+      AppLogger.error('Start recording failed', _tag, e, st);
+      state = RecordingError(message: TamilStrings.errorRecordingFailed);
+    }
+  }
+
+  Future<void> stopRecording() async {
+    try {
+      _cancelTimers();
+      final elapsed = _service.elapsed;
+      final filePath = await _service.stopRecording();
+      final warning = _resolveQualityWarning(_service.qualityWarning);
+
+      state = RecordingComplete(
+        filePath: filePath,
+        duration: elapsed,
+        qualityWarning: warning,
+      );
+
+      AppLogger.info('Recording complete: $filePath (${elapsed.inSeconds}s)', _tag);
+    } catch (e, st) {
+      AppLogger.error('Stop recording failed', _tag, e, st);
+      state = RecordingError(message: TamilStrings.errorRecordingFailed);
+    }
+  }
+
+  Future<void> cancelRecording() async {
+    _cancelTimers();
+    await _service.cancelRecording();
+    state = const RecordingIdle();
+    AppLogger.info('Recording cancelled by user', _tag);
+  }
+
+  void reset() {
+    _cancelTimers();
+    state = const RecordingIdle();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  void _onAmplitude(Amplitude amplitude) {
+    final normalized =
+        AudioRecordingService.normalizeAmplitude(amplitude.current);
+
+    _amplitudes.add(normalized);
+    if (_amplitudes.length > AudioConstants.maxAmplitudeSamples) {
+      _amplitudes.removeAt(0);
+    }
+
+    _service.addAmplitudeSample(amplitude.current);
+
+    state = RecordingActive(
+      elapsed: _service.elapsed,
+      amplitudes: List.unmodifiable(_amplitudes),
+    );
+  }
+
+  void _updateElapsed() {
+    final current = state;
+    if (current is RecordingActive) {
+      state = RecordingActive(
+        elapsed: _service.elapsed,
+        amplitudes: current.amplitudes,
+      );
+    }
+  }
+
+  void _handleAutoStop() {
+    AppLogger.info('Auto-stop triggered at max duration', _tag);
+    stopRecording();
+  }
+
+  void _cancelTimers() {
+    _elapsedTimer?.cancel();
+    _elapsedTimer = null;
+    _amplitudeSub?.cancel();
+    _amplitudeSub = null;
+  }
+
+  String? _resolveQualityWarning(String? quality) {
+    if (quality == null) return null;
+    return switch (quality) {
+      'too_quiet' => TamilStrings.warningTooQuiet,
+      'clipping' => TamilStrings.warningClipping,
+      _ => null,
+    };
+  }
+}

--- a/lib/screens/recording/recording_screen.dart
+++ b/lib/screens/recording/recording_screen.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../config/theme.dart';
+import '../../core/constants/strings_tamil.dart';
+import '../../providers/audio_providers.dart';
+import 'widgets/recording_controls.dart';
+import 'widgets/recording_timer.dart';
+import 'widgets/waveform_painter.dart';
+
+/// Main recording screen with waveform, timer, and controls.
+///
+/// Auto-stops recording if app goes to background.
+class RecordingScreen extends ConsumerStatefulWidget {
+  const RecordingScreen({super.key});
+
+  @override
+  ConsumerState<RecordingScreen> createState() => _RecordingScreenState();
+}
+
+class _RecordingScreenState extends ConsumerState<RecordingScreen>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused) {
+      final recordingState = ref.read(recordingNotifierProvider);
+      if (recordingState is RecordingActive) {
+        ref.read(recordingNotifierProvider.notifier).stopRecording();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final recordingState = ref.watch(recordingNotifierProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(TamilStrings.recordingTitle),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            children: [
+              const Spacer(flex: 2),
+              _buildWaveform(recordingState),
+              const SizedBox(height: 16),
+              _buildTimer(recordingState),
+              const SizedBox(height: 16),
+              _buildStatusText(recordingState),
+              _buildQualityWarning(recordingState),
+              const Spacer(flex: 3),
+              const RecordingControls(),
+              const SizedBox(height: 32),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWaveform(RecordingState recordingState) {
+    final amplitudes = switch (recordingState) {
+      RecordingActive(:final amplitudes) => amplitudes,
+      _ => const <double>[],
+    };
+
+    return RepaintBoundary(
+      child: SizedBox(
+        height: 200,
+        width: double.infinity,
+        child: CustomPaint(
+          painter: WaveformPainter(
+            amplitudes: amplitudes,
+            barColor: NilamTheme.primaryGreen,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTimer(RecordingState recordingState) {
+    final elapsed = switch (recordingState) {
+      RecordingActive(:final elapsed) => elapsed,
+      RecordingComplete(:final duration) => duration,
+      _ => Duration.zero,
+    };
+
+    return RecordingTimer(elapsed: elapsed);
+  }
+
+  Widget _buildStatusText(RecordingState recordingState) {
+    final (text, color) = switch (recordingState) {
+      RecordingIdle() => (TamilStrings.tapToRecord, NilamTheme.onSurfaceVariant),
+      RecordingActive() => (TamilStrings.recordingActive, NilamTheme.primaryGreen),
+      RecordingComplete() => (TamilStrings.recordingComplete, NilamTheme.primaryGreen),
+      RecordingError(:final message) => (message, NilamTheme.redPrimary),
+    };
+
+    return Text(
+      text,
+      style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: color),
+      textAlign: TextAlign.center,
+    );
+  }
+
+  Widget _buildQualityWarning(RecordingState recordingState) {
+    if (recordingState is! RecordingComplete ||
+        recordingState.qualityWarning == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.warning_amber, color: NilamTheme.warmAmber, size: 20),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              recordingState.qualityWarning!,
+              style: const TextStyle(
+                color: NilamTheme.warmAmber,
+                fontSize: 13,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/recording/widgets/recording_controls.dart
+++ b/lib/screens/recording/widgets/recording_controls.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../config/theme.dart';
+import '../../../core/constants/strings_tamil.dart';
+import '../../../providers/audio_providers.dart';
+
+/// Recording control buttons that change based on [RecordingState].
+class RecordingControls extends ConsumerWidget {
+  const RecordingControls({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final recordingState = ref.watch(recordingNotifierProvider);
+    final notifier = ref.read(recordingNotifierProvider.notifier);
+
+    return switch (recordingState) {
+      RecordingIdle() => _buildRecordButton(notifier),
+      RecordingActive() => _buildActiveControls(notifier),
+      RecordingComplete() => _buildCompleteControls(notifier),
+      RecordingError(:final message) => _buildErrorControls(notifier, message),
+    };
+  }
+
+  Widget _buildRecordButton(RecordingNotifier notifier) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 80,
+          height: 80,
+          child: FloatingActionButton(
+            heroTag: 'record_btn',
+            onPressed: notifier.startRecording,
+            backgroundColor: NilamTheme.warmAmber,
+            child: const Icon(Icons.mic, size: 36, color: NilamTheme.onSurface),
+          ),
+        ),
+        const SizedBox(height: 12),
+        const Text(
+          TamilStrings.tapToRecord,
+          style: TextStyle(
+            color: NilamTheme.onSurfaceVariant,
+            fontSize: 14,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildActiveControls(RecordingNotifier notifier) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        OutlinedButton.icon(
+          onPressed: notifier.cancelRecording,
+          icon: const Icon(Icons.close),
+          label: const Text(TamilStrings.cancel),
+          style: OutlinedButton.styleFrom(
+            minimumSize: const Size(120, 48),
+            side: const BorderSide(color: NilamTheme.outline),
+          ),
+        ),
+        const SizedBox(width: 24),
+        SizedBox(
+          width: 72,
+          height: 72,
+          child: FloatingActionButton(
+            heroTag: 'stop_btn',
+            onPressed: notifier.stopRecording,
+            backgroundColor: NilamTheme.redPrimary,
+            child:
+                const Icon(Icons.stop, size: 32, color: Colors.white),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCompleteControls(RecordingNotifier notifier) {
+    return ElevatedButton.icon(
+      onPressed: notifier.reset,
+      icon: const Icon(Icons.mic),
+      label: const Text(TamilStrings.record),
+      style: ElevatedButton.styleFrom(
+        minimumSize: const Size(160, 48),
+      ),
+    );
+  }
+
+  Widget _buildErrorControls(RecordingNotifier notifier, String message) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          message,
+          style: const TextStyle(color: NilamTheme.redPrimary, fontSize: 14),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 16),
+        ElevatedButton.icon(
+          onPressed: notifier.reset,
+          icon: const Icon(Icons.refresh),
+          label: const Text(TamilStrings.retry),
+          style: ElevatedButton.styleFrom(
+            minimumSize: const Size(160, 48),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/recording/widgets/recording_timer.dart
+++ b/lib/screens/recording/widgets/recording_timer.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import '../../../config/theme.dart';
+import '../../../services/audio/audio_constants.dart';
+
+/// Displays elapsed recording time as `M:SS / 2:00`.
+///
+/// Text turns red when elapsed exceeds the warning threshold (100s).
+class RecordingTimer extends StatelessWidget {
+  const RecordingTimer({
+    super.key,
+    required this.elapsed,
+    this.maxSeconds = AudioConstants.maxDurationSeconds,
+  });
+
+  final Duration elapsed;
+  final int maxSeconds;
+
+  static const int _warningThresholdSeconds = 100;
+
+  @override
+  Widget build(BuildContext context) {
+    final isWarning = elapsed.inSeconds >= _warningThresholdSeconds;
+    final theme = Theme.of(context);
+
+    return Text(
+      '${_format(elapsed)} / ${_format(Duration(seconds: maxSeconds))}',
+      style: theme.textTheme.headlineSmall?.copyWith(
+        color: isWarning ? NilamTheme.redPrimary : NilamTheme.onSurface,
+        fontFeatures: const [FontFeature.tabularFigures()],
+      ),
+    );
+  }
+
+  static String _format(Duration d) {
+    final minutes = d.inMinutes;
+    final seconds = d.inSeconds % 60;
+    return '$minutes:${seconds.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/screens/recording/widgets/waveform_painter.dart
+++ b/lib/screens/recording/widgets/waveform_painter.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+import '../../../services/audio/audio_constants.dart';
+
+/// Custom painter that draws vertical amplitude bars for waveform visualization.
+///
+/// Each bar is mirrored above and below the horizontal center line.
+class WaveformPainter extends CustomPainter {
+  WaveformPainter({
+    required this.amplitudes,
+    required this.barColor,
+  });
+
+  final List<double> amplitudes;
+  final Color barColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (amplitudes.isEmpty) return;
+
+    final barCount = AudioConstants.maxAmplitudeSamples;
+    final gap = 1.0;
+    final barWidth = (size.width - (barCount - 1) * gap) / barCount;
+    final centerY = size.height / 2;
+    final maxBarHeight = size.height / 2;
+
+    final paint = Paint()..strokeCap = StrokeCap.round;
+
+    final startIndex =
+        amplitudes.length > barCount ? amplitudes.length - barCount : 0;
+    final visibleAmplitudes = amplitudes.sublist(startIndex);
+
+    for (var i = 0; i < visibleAmplitudes.length; i++) {
+      final amplitude = visibleAmplitudes[i];
+      final barHeight = (amplitude * maxBarHeight).clamp(1.0, maxBarHeight);
+      final x = i * (barWidth + gap) + barWidth / 2;
+
+      paint.color = barColor.withValues(alpha: 0.4 + amplitude * 0.6);
+      paint.strokeWidth = barWidth;
+
+      canvas.drawLine(
+        Offset(x, centerY - barHeight),
+        Offset(x, centerY + barHeight),
+        paint,
+      );
+    }
+
+    // Draw center line.
+    final linePaint = Paint()
+      ..color = barColor.withValues(alpha: 0.2)
+      ..strokeWidth = 0.5;
+    canvas.drawLine(
+      Offset(0, centerY),
+      Offset(size.width, centerY),
+      linePaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(WaveformPainter oldDelegate) {
+    return amplitudes.length != oldDelegate.amplitudes.length ||
+        !identical(amplitudes, oldDelegate.amplitudes);
+  }
+}

--- a/lib/services/audio/audio_constants.dart
+++ b/lib/services/audio/audio_constants.dart
@@ -1,0 +1,32 @@
+/// Audio recording configuration constants for NilamAI.
+///
+/// PCM 16-bit, 16 kHz, mono — optimized for Whisper STT ingestion.
+class AudioConstants {
+  AudioConstants._();
+
+  // -- Recording config --
+  static const int sampleRate = 16000;
+  static const int numChannels = 1;
+  static const int bitRate = 256000; // 16-bit * 16000 Hz
+
+  // -- Duration constraints --
+  static const int minDurationSeconds = 10;
+  static const int maxDurationSeconds = 120;
+
+  // -- Amplitude monitoring --
+  static const int amplitudeIntervalMs = 33; // ~30 FPS
+  static const int maxAmplitudeSamples = 150;
+
+  // -- Audio quality thresholds (dBFS) --
+  static const double silenceThresholdDb = -30.0;
+  static const double clippingThresholdDb = -1.0;
+
+  // -- Normalization range --
+  static const double minDb = -60.0;
+  static const double maxDb = 0.0;
+
+  // -- File naming --
+  static const String filePrefix = 'nilam_query_';
+  static const String fileExtension = '.wav';
+  static const String audioSubDir = 'audio';
+}

--- a/lib/services/audio/audio_recording_service.dart
+++ b/lib/services/audio/audio_recording_service.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+import 'package:record/record.dart';
+
+import '../../core/exceptions/app_exception.dart';
+import '../../core/logging/logger.dart';
+import 'audio_constants.dart';
+
+/// Core audio recording service wrapping the `record` package.
+///
+/// Captures PCM 16-bit, 16 kHz, mono WAV for Whisper STT ingestion.
+class AudioRecordingService {
+  AudioRecordingService(this._recorder);
+
+  static const _tag = 'AudioRecordingService';
+
+  final AudioRecorder _recorder;
+  Timer? _maxDurationTimer;
+  DateTime? _startTime;
+  String? _currentFilePath;
+
+  final List<double> _rawAmplitudes = [];
+
+  /// Callback invoked when max duration auto-stop triggers.
+  void Function()? onAutoStop;
+
+  // ---------------------------------------------------------------------------
+  // Permission
+  // ---------------------------------------------------------------------------
+
+  Future<bool> checkPermission() async {
+    try {
+      final granted = await _recorder.hasPermission();
+      AppLogger.debug(
+        'Microphone permission ${granted ? "granted" : "denied"}',
+        _tag,
+      );
+      return granted;
+    } catch (e, st) {
+      AppLogger.error('Permission check failed', _tag, e, st);
+      return false;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Recording lifecycle
+  // ---------------------------------------------------------------------------
+
+  Future<void> startRecording() async {
+    try {
+      final supported =
+          await _recorder.isEncoderSupported(AudioEncoder.wav);
+      if (!supported) {
+        throw const AudioException(
+          message: 'WAV encoder not supported on this device',
+        );
+      }
+
+      final dir = await _audioDirectory();
+      _currentFilePath = generateFilePath(dir, DateTime.now());
+
+      const config = RecordConfig(
+        encoder: AudioEncoder.wav,
+        sampleRate: AudioConstants.sampleRate,
+        numChannels: AudioConstants.numChannels,
+        bitRate: AudioConstants.bitRate,
+        autoGain: true,
+        noiseSuppress: true,
+      );
+
+      await _recorder.start(config, path: _currentFilePath!);
+      _startTime = DateTime.now();
+      _rawAmplitudes.clear();
+
+      _maxDurationTimer = Timer(
+        const Duration(seconds: AudioConstants.maxDurationSeconds),
+        _onMaxDuration,
+      );
+
+      AppLogger.info('Recording started: $_currentFilePath', _tag);
+    } catch (e, st) {
+      _cleanup();
+      if (e is AudioException) rethrow;
+      AppLogger.error('Start recording failed', _tag, e, st);
+      throw AudioException(message: 'Recording failed to start', originalError: e);
+    }
+  }
+
+  Future<String> stopRecording() async {
+    try {
+      _maxDurationTimer?.cancel();
+      _maxDurationTimer = null;
+
+      final path = await _recorder.stop();
+      final filePath = path ?? _currentFilePath;
+
+      if (filePath == null || !File(filePath).existsSync()) {
+        throw const AudioException(message: 'Recording file not found');
+      }
+
+      AppLogger.info('Recording stopped: $filePath', _tag);
+      _currentFilePath = null;
+      return filePath;
+    } catch (e, st) {
+      if (e is AudioException) rethrow;
+      AppLogger.error('Stop recording failed', _tag, e, st);
+      throw AudioException(message: 'Failed to stop recording', originalError: e);
+    }
+  }
+
+  Future<void> cancelRecording() async {
+    try {
+      _cleanup();
+      await _recorder.cancel();
+      AppLogger.info('Recording cancelled', _tag);
+    } catch (e, st) {
+      AppLogger.error('Cancel recording failed', _tag, e, st);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Streams
+  // ---------------------------------------------------------------------------
+
+  Stream<Amplitude> get amplitudeStream => _recorder.onAmplitudeChanged(
+        const Duration(milliseconds: AudioConstants.amplitudeIntervalMs),
+      );
+
+  Stream<RecordState> get recordStateStream => _recorder.onStateChanged();
+
+  // ---------------------------------------------------------------------------
+  // Duration tracking
+  // ---------------------------------------------------------------------------
+
+  Duration get elapsed {
+    if (_startTime == null) return Duration.zero;
+    return DateTime.now().difference(_startTime!);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Amplitude collection for quality analysis
+  // ---------------------------------------------------------------------------
+
+  void addAmplitudeSample(double dbFS) {
+    _rawAmplitudes.add(dbFS);
+  }
+
+  String? get qualityWarning => analyzeQuality(_rawAmplitudes);
+
+  // ---------------------------------------------------------------------------
+  // Cleanup
+  // ---------------------------------------------------------------------------
+
+  Future<void> dispose() async {
+    _cleanup();
+    await _recorder.dispose();
+    AppLogger.debug('AudioRecordingService disposed', _tag);
+  }
+
+  void _cleanup() {
+    _maxDurationTimer?.cancel();
+    _maxDurationTimer = null;
+    _startTime = null;
+    _currentFilePath = null;
+  }
+
+  void _onMaxDuration() {
+    AppLogger.info('Max recording duration reached (${AudioConstants.maxDurationSeconds}s)', _tag);
+    onAutoStop?.call();
+  }
+
+  Future<String> _audioDirectory() async {
+    final appDir = await getApplicationDocumentsDirectory();
+    final audioDir = Directory('${appDir.path}/${AudioConstants.audioSubDir}');
+    if (!audioDir.existsSync()) {
+      audioDir.createSync(recursive: true);
+    }
+    return audioDir.path;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pure static functions (testable without platform)
+  // ---------------------------------------------------------------------------
+
+  /// Normalizes a dBFS value (-60..0) to a 0.0..1.0 range for waveform display.
+  static double normalizeAmplitude(double dbFS) {
+    return ((dbFS - AudioConstants.minDb) /
+            (AudioConstants.maxDb - AudioConstants.minDb))
+        .clamp(0.0, 1.0);
+  }
+
+  /// Analyzes collected amplitude samples for quality issues.
+  ///
+  /// Returns `'too_quiet'`, `'clipping'`, or `null` if quality is acceptable.
+  static String? analyzeQuality(List<double> amplitudes) {
+    if (amplitudes.isEmpty) return null;
+
+    final average =
+        amplitudes.reduce((a, b) => a + b) / amplitudes.length;
+
+    if (average < AudioConstants.silenceThresholdDb) {
+      return 'too_quiet';
+    }
+
+    final hasClipping =
+        amplitudes.any((a) => a > AudioConstants.clippingThresholdDb);
+    if (hasClipping) {
+      return 'clipping';
+    }
+
+    return null;
+  }
+
+  /// Generates a WAV file path from a directory and timestamp.
+  static String generateFilePath(String dir, DateTime now) {
+    final timestamp = now.millisecondsSinceEpoch;
+    return '$dir/${AudioConstants.filePrefix}$timestamp${AudioConstants.fileExtension}';
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   uuid: ^4.5.1
   shared_preferences: ^2.2.3
   crypto: ^3.0.7
+  path_provider: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/providers/audio_providers_test.dart
+++ b/test/providers/audio_providers_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nilam_ai/providers/audio_providers.dart';
+
+void main() {
+  group('RecordingState', () {
+    test('RecordingIdle is the initial state', () {
+      const state = RecordingIdle();
+      expect(state, isA<RecordingState>());
+      expect(state, isA<RecordingIdle>());
+    });
+
+    test('RecordingActive carries elapsed and amplitudes', () {
+      const state = RecordingActive(
+        elapsed: Duration(seconds: 5),
+        amplitudes: [0.1, 0.5, 0.8],
+      );
+      expect(state.elapsed, equals(const Duration(seconds: 5)));
+      expect(state.amplitudes.length, equals(3));
+    });
+
+    test('RecordingComplete carries filePath and duration', () {
+      const state = RecordingComplete(
+        filePath: '/audio/test.wav',
+        duration: Duration(seconds: 30),
+      );
+      expect(state.filePath, equals('/audio/test.wav'));
+      expect(state.duration, equals(const Duration(seconds: 30)));
+      expect(state.qualityWarning, isNull);
+    });
+
+    test('RecordingComplete carries optional quality warning', () {
+      const state = RecordingComplete(
+        filePath: '/audio/test.wav',
+        duration: Duration(seconds: 30),
+        qualityWarning: 'too quiet',
+      );
+      expect(state.qualityWarning, equals('too quiet'));
+    });
+
+    test('RecordingError carries message', () {
+      const state = RecordingError(message: 'Mic denied');
+      expect(state.message, equals('Mic denied'));
+    });
+
+    test('exhaustive switch covers all states', () {
+      final states = <RecordingState>[
+        const RecordingIdle(),
+        const RecordingActive(elapsed: Duration.zero, amplitudes: []),
+        const RecordingComplete(
+          filePath: '/test.wav',
+          duration: Duration.zero,
+        ),
+        const RecordingError(message: 'error'),
+      ];
+
+      for (final state in states) {
+        final label = switch (state) {
+          RecordingIdle() => 'idle',
+          RecordingActive() => 'active',
+          RecordingComplete() => 'complete',
+          RecordingError() => 'error',
+        };
+        expect(label, isNotEmpty);
+      }
+    });
+  });
+
+  group('recordingNotifierProvider', () {
+    test('initial state is RecordingIdle', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final state = container.read(recordingNotifierProvider);
+      expect(state, isA<RecordingIdle>());
+    });
+
+    test('reset returns to RecordingIdle', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(recordingNotifierProvider.notifier).reset();
+      final state = container.read(recordingNotifierProvider);
+      expect(state, isA<RecordingIdle>());
+    });
+  });
+}

--- a/test/screens/recording/recording_screen_test.dart
+++ b/test/screens/recording/recording_screen_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nilam_ai/config/theme.dart';
+import 'package:nilam_ai/core/constants/strings_tamil.dart';
+import 'package:nilam_ai/providers/audio_providers.dart';
+import 'package:nilam_ai/screens/recording/recording_screen.dart';
+
+/// A fake notifier that exposes a fixed state.
+class FakeRecordingNotifier extends RecordingNotifier {
+  FakeRecordingNotifier(this._initialState);
+
+  final RecordingState _initialState;
+
+  @override
+  RecordingState build() => _initialState;
+
+  @override
+  Future<void> startRecording() async {}
+
+  @override
+  Future<void> stopRecording() async {}
+
+  @override
+  Future<void> cancelRecording() async {}
+}
+
+Widget _buildTestApp(RecordingState initialState) {
+  return ProviderScope(
+    overrides: [
+      recordingNotifierProvider.overrideWith(
+        () => FakeRecordingNotifier(initialState),
+      ),
+    ],
+    child: MaterialApp(
+      theme: NilamTheme.lightTheme,
+      home: const RecordingScreen(),
+    ),
+  );
+}
+
+void main() {
+  group('RecordingScreen', () {
+    testWidgets('shows record button and hint text in idle state',
+        (tester) async {
+      await tester.pumpWidget(_buildTestApp(const RecordingIdle()));
+      await tester.pumpAndSettle();
+
+      expect(find.text(TamilStrings.tapToRecord), findsWidgets);
+      expect(find.byIcon(Icons.mic), findsOneWidget);
+    });
+
+    testWidgets('shows app bar with recording title', (tester) async {
+      await tester.pumpWidget(_buildTestApp(const RecordingIdle()));
+      await tester.pumpAndSettle();
+
+      expect(find.text(TamilStrings.recordingTitle), findsOneWidget);
+    });
+
+    testWidgets('shows stop and cancel buttons in active state',
+        (tester) async {
+      await tester.pumpWidget(_buildTestApp(
+        const RecordingActive(
+          elapsed: Duration(seconds: 5),
+          amplitudes: [0.1, 0.5, 0.8],
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.stop), findsOneWidget);
+      expect(find.text(TamilStrings.cancel), findsOneWidget);
+      expect(find.text(TamilStrings.recordingActive), findsOneWidget);
+    });
+
+    testWidgets('shows timer in active state', (tester) async {
+      await tester.pumpWidget(_buildTestApp(
+        const RecordingActive(
+          elapsed: Duration(seconds: 45),
+          amplitudes: [],
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('0:45 / 2:00'), findsOneWidget);
+    });
+
+    testWidgets('shows complete state with record button', (tester) async {
+      await tester.pumpWidget(_buildTestApp(
+        const RecordingComplete(
+          filePath: '/test/audio.wav',
+          duration: Duration(seconds: 30),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text(TamilStrings.recordingComplete), findsOneWidget);
+      expect(find.text(TamilStrings.record), findsOneWidget);
+    });
+
+    testWidgets('shows quality warning when present', (tester) async {
+      await tester.pumpWidget(_buildTestApp(
+        const RecordingComplete(
+          filePath: '/test/audio.wav',
+          duration: Duration(seconds: 30),
+          qualityWarning: TamilStrings.warningTooQuiet,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text(TamilStrings.warningTooQuiet), findsOneWidget);
+      expect(find.byIcon(Icons.warning_amber), findsOneWidget);
+    });
+
+    testWidgets('does not show quality warning when null', (tester) async {
+      await tester.pumpWidget(_buildTestApp(
+        const RecordingComplete(
+          filePath: '/test/audio.wav',
+          duration: Duration(seconds: 30),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.warning_amber), findsNothing);
+    });
+
+    testWidgets('shows error state with retry button', (tester) async {
+      await tester.pumpWidget(_buildTestApp(
+        const RecordingError(message: TamilStrings.errorMicrophone),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text(TamilStrings.errorMicrophone), findsWidgets);
+      expect(find.text(TamilStrings.retry), findsOneWidget);
+      expect(find.byIcon(Icons.refresh), findsOneWidget);
+    });
+
+    testWidgets('timer shows 0:00 / 2:00 in idle state', (tester) async {
+      await tester.pumpWidget(_buildTestApp(const RecordingIdle()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('0:00 / 2:00'), findsOneWidget);
+    });
+  });
+}

--- a/test/screens/recording/widgets/waveform_painter_test.dart
+++ b/test/screens/recording/widgets/waveform_painter_test.dart
@@ -1,0 +1,77 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/screens/recording/widgets/waveform_painter.dart';
+
+void main() {
+  group('WaveformPainter', () {
+    test('shouldRepaint returns true for different amplitude lists', () {
+      final painter1 = WaveformPainter(
+        amplitudes: const [0.1, 0.2],
+        barColor: Colors.green,
+      );
+      final painter2 = WaveformPainter(
+        amplitudes: const [0.1, 0.2, 0.3],
+        barColor: Colors.green,
+      );
+      expect(painter1.shouldRepaint(painter2), isTrue);
+    });
+
+    test('shouldRepaint returns false for identical lists', () {
+      final amplitudes = [0.1, 0.2, 0.3];
+      final painter1 = WaveformPainter(
+        amplitudes: amplitudes,
+        barColor: Colors.green,
+      );
+      final painter2 = WaveformPainter(
+        amplitudes: amplitudes,
+        barColor: Colors.green,
+      );
+      expect(painter1.shouldRepaint(painter2), isFalse);
+    });
+
+    test('shouldRepaint returns true for non-identical same-length lists', () {
+      final painter1 = WaveformPainter(
+        amplitudes: [0.1, 0.2],
+        barColor: Colors.green,
+      );
+      final painter2 = WaveformPainter(
+        amplitudes: [0.1, 0.2],
+        barColor: Colors.green,
+      );
+      // Non-const list instances are not identical
+      expect(painter1.shouldRepaint(painter2), isTrue);
+    });
+
+    test('paint does not crash with empty amplitudes', () {
+      final painter = WaveformPainter(
+        amplitudes: const [],
+        barColor: Colors.green,
+      );
+
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder);
+      const size = Size(300, 200);
+
+      // Should complete without throwing.
+      painter.paint(canvas, size);
+      recorder.endRecording();
+    });
+
+    test('paint draws bars for non-empty amplitudes', () {
+      final painter = WaveformPainter(
+        amplitudes: const [0.5, 0.8, 0.3],
+        barColor: Colors.green,
+      );
+
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder);
+      const size = Size(300, 200);
+
+      // Should complete without throwing.
+      painter.paint(canvas, size);
+      recorder.endRecording();
+    });
+  });
+}

--- a/test/services/audio/audio_constants_test.dart
+++ b/test/services/audio/audio_constants_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/services/audio/audio_constants.dart';
+
+void main() {
+  group('AudioConstants', () {
+    test('sampleRate is 16kHz for Whisper STT', () {
+      expect(AudioConstants.sampleRate, equals(16000));
+    });
+
+    test('numChannels is mono', () {
+      expect(AudioConstants.numChannels, equals(1));
+    });
+
+    test('bitRate matches 16-bit * 16kHz', () {
+      expect(AudioConstants.bitRate, equals(256000));
+    });
+
+    test('maxDurationSeconds is 120', () {
+      expect(AudioConstants.maxDurationSeconds, equals(120));
+    });
+
+    test('minDurationSeconds is 10', () {
+      expect(AudioConstants.minDurationSeconds, equals(10));
+    });
+
+    test('amplitudeIntervalMs targets ~30 FPS', () {
+      expect(AudioConstants.amplitudeIntervalMs, equals(33));
+      // 1000ms / 33ms ≈ 30 FPS
+      expect(1000 / AudioConstants.amplitudeIntervalMs,
+          closeTo(30, 1));
+    });
+
+    test('silence threshold is below clipping threshold', () {
+      expect(AudioConstants.silenceThresholdDb,
+          lessThan(AudioConstants.clippingThresholdDb));
+    });
+
+    test('file extension is .wav', () {
+      expect(AudioConstants.fileExtension, equals('.wav'));
+    });
+
+    test('normalization range spans 60 dB', () {
+      expect(
+        AudioConstants.maxDb - AudioConstants.minDb,
+        equals(60.0),
+      );
+    });
+  });
+}

--- a/test/services/audio/audio_recording_service_test.dart
+++ b/test/services/audio/audio_recording_service_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/services/audio/audio_constants.dart';
+import 'package:nilam_ai/services/audio/audio_recording_service.dart';
+
+void main() {
+  group('AudioRecordingService.normalizeAmplitude', () {
+    test('maps minDb (-60) to 0.0', () {
+      expect(
+        AudioRecordingService.normalizeAmplitude(AudioConstants.minDb),
+        equals(0.0),
+      );
+    });
+
+    test('maps maxDb (0) to 1.0', () {
+      expect(
+        AudioRecordingService.normalizeAmplitude(AudioConstants.maxDb),
+        equals(1.0),
+      );
+    });
+
+    test('maps midpoint (-30) to 0.5', () {
+      expect(
+        AudioRecordingService.normalizeAmplitude(-30.0),
+        equals(0.5),
+      );
+    });
+
+    test('clamps values below minDb to 0.0', () {
+      expect(
+        AudioRecordingService.normalizeAmplitude(-100.0),
+        equals(0.0),
+      );
+    });
+
+    test('clamps values above maxDb to 1.0', () {
+      expect(
+        AudioRecordingService.normalizeAmplitude(5.0),
+        equals(1.0),
+      );
+    });
+
+    test('returns proportional value for -15 dBFS', () {
+      // (-15 - (-60)) / (0 - (-60)) = 45/60 = 0.75
+      expect(
+        AudioRecordingService.normalizeAmplitude(-15.0),
+        closeTo(0.75, 0.001),
+      );
+    });
+  });
+
+  group('AudioRecordingService.analyzeQuality', () {
+    test('returns null for empty amplitudes', () {
+      expect(AudioRecordingService.analyzeQuality([]), isNull);
+    });
+
+    test('returns null for normal audio levels', () {
+      final amplitudes = List.filled(100, -15.0);
+      expect(AudioRecordingService.analyzeQuality(amplitudes), isNull);
+    });
+
+    test('returns too_quiet for very low average', () {
+      final amplitudes = List.filled(100, -45.0);
+      expect(
+        AudioRecordingService.analyzeQuality(amplitudes),
+        equals('too_quiet'),
+      );
+    });
+
+    test('returns too_quiet when average is exactly at threshold', () {
+      // Average < -30 dBFS
+      final amplitudes = List.filled(100, -31.0);
+      expect(
+        AudioRecordingService.analyzeQuality(amplitudes),
+        equals('too_quiet'),
+      );
+    });
+
+    test('returns clipping when any sample exceeds threshold', () {
+      final amplitudes = List.filled(100, -15.0);
+      amplitudes[50] = -0.5; // Above -1.0 dBFS
+      expect(
+        AudioRecordingService.analyzeQuality(amplitudes),
+        equals('clipping'),
+      );
+    });
+
+    test('too_quiet takes priority over clipping', () {
+      // If average is too quiet, that's the primary issue
+      final amplitudes = List.filled(100, -50.0);
+      amplitudes[50] = -0.5;
+      expect(
+        AudioRecordingService.analyzeQuality(amplitudes),
+        equals('too_quiet'),
+      );
+    });
+
+    test('returns null when average is exactly at silence boundary', () {
+      // Average == -30 is NOT < -30, so should be null
+      final amplitudes = List.filled(100, -30.0);
+      expect(AudioRecordingService.analyzeQuality(amplitudes), isNull);
+    });
+  });
+
+  group('AudioRecordingService.generateFilePath', () {
+    test('generates path with correct prefix and extension', () {
+      final path = AudioRecordingService.generateFilePath(
+        '/test/dir',
+        DateTime(2026, 4, 17, 10, 0),
+      );
+      expect(path, startsWith('/test/dir/${AudioConstants.filePrefix}'));
+      expect(path, endsWith(AudioConstants.fileExtension));
+    });
+
+    test('includes timestamp in milliseconds', () {
+      final now = DateTime(2026, 4, 17, 10, 0);
+      final path = AudioRecordingService.generateFilePath('/dir', now);
+      expect(path, contains(now.millisecondsSinceEpoch.toString()));
+    });
+
+    test('different timestamps produce different paths', () {
+      final t1 = DateTime(2026, 4, 17, 10, 0);
+      final t2 = DateTime(2026, 4, 17, 10, 1);
+      final path1 = AudioRecordingService.generateFilePath('/dir', t1);
+      final path2 = AudioRecordingService.generateFilePath('/dir', t2);
+      expect(path1, isNot(equals(path2)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `AudioRecordingService` wrapping `record` package for PCM 16-bit, 16kHz, mono WAV capture with 120s auto-stop, permission handling, and audio quality analysis
- Add recording screen with real-time waveform visualization (`CustomPainter`, ~30 FPS), elapsed timer, and state-aware controls (record/stop/cancel/retry)
- Add sealed `RecordingState` state machine with `RecordingNotifier` (Riverpod) managing full recording lifecycle (Idle → Active → Complete/Error)
- Add 12 Tamil UI strings (recording, permissions, quality warnings, errors) and `RECORD_AUDIO` Android permission
- Add 47 tests: audio constants (9), service pure functions (16), provider states (8), waveform painter (5), recording screen widget tests (9)

## Scope deviations from Issue #3
1. **No `permission_handler` dependency** — `AudioRecorder.hasPermission()` from the `record` package handles runtime permission natively; avoids redundant dependency
2. **Audio quality as warnings, not hard errors** — Too-quiet (E003) and clipping (E004) are detected post-recording and shown as Tamil warnings; recording still succeeds. Only E001 (mic unavailable) and E002 (codec unsupported) are blocking errors
3. **Added `path_provider`** — For reliable WAV file storage in app documents directory instead of temp directory (prevents OS cleanup before transcription in Phase 4)

## Verification
- `flutter analyze` — 0 issues
- 47/47 Phase 3 tests pass
- On-device test (Moto G34 5G): recorded 2 WAV files successfully with waveform + timer working
- Permission prompt shown on first recording attempt

## Test plan
- [x] `flutter analyze` passes with 0 issues
- [x] `flutter test` — all 47 new tests pass
- [x] On-device: tap mic FAB → navigate to recording screen
- [x] On-device: tap record → permission prompt → waveform + timer active
- [x] On-device: tap stop → recording complete state with file path logged
- [ ] On-device: deny mic permission → Tamil error shown
- [ ] On-device: let recording run to 120s → auto-stop triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)