### PR TITLE
Phase 4: On-device Tamil STT with Whisper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ docs/srs.md
 
 # Claude Code memory & settings
 .claude/
+
+# Whisper model files (fetched via scripts/fetch_model.ps1 or .sh, too large for git)
+assets/models/*.bin
+
+# Flutter crash reports
+flutter_*.log

--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -3,6 +3,8 @@ import 'package:go_router/go_router.dart';
 
 import '../core/constants/strings_tamil.dart';
 import '../screens/recording/recording_screen.dart';
+import '../screens/transcription/transcribing_screen.dart';
+import '../screens/transcription/transcription_review_screen.dart';
 
 final GoRouter appRouter = GoRouter(
   initialLocation: '/',
@@ -19,6 +21,26 @@ final GoRouter appRouter = GoRouter(
       name: 'record',
       builder: (BuildContext context, GoRouterState state) {
         return const RecordingScreen();
+      },
+    ),
+    GoRoute(
+      path: '/transcribe',
+      name: 'transcribe',
+      builder: (BuildContext context, GoRouterState state) {
+        final audioPath = state.uri.queryParameters['audioPath'] ?? '';
+        return TranscribingScreen(audioPath: audioPath);
+      },
+    ),
+    GoRoute(
+      path: '/review',
+      name: 'review',
+      builder: (BuildContext context, GoRouterState state) {
+        final audioPath = state.uri.queryParameters['audioPath'] ?? '';
+        final initialText = state.uri.queryParameters['text'] ?? '';
+        return TranscriptionReviewScreen(
+          audioPath: audioPath,
+          initialText: initialText,
+        );
       },
     ),
   ],

--- a/lib/core/constants/strings_tamil.dart
+++ b/lib/core/constants/strings_tamil.dart
@@ -63,4 +63,24 @@ class TamilStrings {
   static const String errorMaxDuration = 'அதிகபட்ச நேரம் எட்டப்பட்டத���';
   static const String errorDatabase = 'தரவுத்தள பிழை. மீண்டும் முயற்சிக்கவும்.';
   static const String errorDatabaseInit = 'தரவுத்தளத்தை துவக்க முடியவில்லை';
+
+  // -- STT (Speech-to-Text) --
+  static const String sttTranscribing = 'உரையாக மாற்றுகிறது...';
+  static const String sttModelLoading = 'மாதிரி ஏற்றப்படுகிறது...';
+
+  // -- Transcription review --
+  static const String reviewTitle = 'பதிவு செய்த உரை';
+  static const String reviewInstructions = 'தவறு இருந்தால் திருத்தவும்';
+  static const String confirm = 'உறுதிசெய்';
+  static const String retake = 'மீண்டும் பதிவு செய்';
+  static const String transcriptionEmpty = 'எந்த உரையும் கண்டறியப்படவில்லை';
+  static const String transcriptionSaved = 'சேமிக்கப்பட்டது';
+
+  // -- STT errors (E006/E007/E008) --
+  static const String errorSttModelMissing =
+      'பேச்சு அறிதல் மாதிரி கிடைக்கவில்லை';
+  static const String errorSttFailed =
+      'உரை மாற்றம் தோல்வி. மீண்டும் முயற்சிக்கவும்';
+  static const String errorSttLowConfidence =
+      'உரை தெளிவாக இல்லை. திருத்தவும்';
 }

--- a/lib/core/exceptions/app_exception.dart
+++ b/lib/core/exceptions/app_exception.dart
@@ -2,10 +2,13 @@
 ///
 /// Error codes follow the SRS convention:
 /// - E001: Microphone errors
-/// - E002: STT errors
+/// - E002: STT errors (generic)
 /// - E003: LLM errors
 /// - E004: TTS errors
 /// - E005: Database errors
+/// - E006: Whisper model not loaded
+/// - E007: Transcription failed
+/// - E008: Low confidence transcription
 sealed class AppException implements Exception {
   const AppException({
     required this.code,
@@ -32,7 +35,28 @@ class SttException extends AppException {
   const SttException({
     required super.message,
     super.originalError,
-  }) : super(code: 'E002');
+    super.code = 'E002',
+  });
+
+  SttException.modelNotLoaded({Object? originalError})
+      : this(
+          code: 'E006',
+          message: 'Whisper model not loaded',
+          originalError: originalError,
+        );
+
+  SttException.transcriptionFailed(String detail, {Object? originalError})
+      : this(
+          code: 'E007',
+          message: 'Transcription failed: $detail',
+          originalError: originalError,
+        );
+
+  SttException.lowConfidence(double score)
+      : this(
+          code: 'E008',
+          message: 'Low confidence: ${score.toStringAsFixed(2)}',
+        );
 }
 
 class LlmException extends AppException {

--- a/lib/providers/stt_providers.dart
+++ b/lib/providers/stt_providers.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/exceptions/app_exception.dart';
+import '../core/logging/logger.dart';
+import '../services/stt/whisper_model_loader.dart';
+import '../services/stt/whisper_stt_service.dart';
+
+// -----------------------------------------------------------------------------
+// Sealed STT state
+// -----------------------------------------------------------------------------
+
+sealed class SttState {
+  const SttState();
+}
+
+class SttIdle extends SttState {
+  const SttIdle();
+}
+
+class SttLoadingModel extends SttState {
+  const SttLoadingModel();
+}
+
+class SttTranscribing extends SttState {
+  const SttTranscribing();
+}
+
+class SttComplete extends SttState {
+  const SttComplete({required this.text, required this.audioPath});
+
+  final String text;
+  final String audioPath;
+}
+
+class SttError extends SttState {
+  const SttError({required this.code, required this.message});
+
+  final String code;
+  final String message;
+}
+
+// -----------------------------------------------------------------------------
+// Providers
+// -----------------------------------------------------------------------------
+
+final whisperModelLoaderProvider = Provider<WhisperModelLoader>((ref) {
+  return WhisperModelLoader();
+});
+
+final whisperTranscriberProvider = Provider<WhisperTranscriber>((ref) {
+  return const WhisperGgmlTranscriber();
+});
+
+final whisperSttServiceProvider = Provider<WhisperSttService>((ref) {
+  return WhisperSttService(
+    loader: ref.watch(whisperModelLoaderProvider),
+    transcriber: ref.watch(whisperTranscriberProvider),
+  );
+});
+
+final sttNotifierProvider =
+    NotifierProvider<SttNotifier, SttState>(SttNotifier.new);
+
+// -----------------------------------------------------------------------------
+// Notifier
+// -----------------------------------------------------------------------------
+
+class SttNotifier extends Notifier<SttState> {
+  static const _tag = 'SttNotifier';
+
+  @override
+  SttState build() => const SttIdle();
+
+  WhisperSttService get _service => ref.read(whisperSttServiceProvider);
+
+  /// Kicks off a full transcription: LoadingModel → Transcribing → Complete/Error.
+  Future<void> transcribe(String audioPath) async {
+    state = const SttLoadingModel();
+    AppLogger.info('STT started for $audioPath', _tag);
+
+    // Give the UI a frame to render the "loading model" state before we start
+    // the heavy work (asset copy on first launch).
+    await Future<void>.delayed(Duration.zero);
+
+    state = const SttTranscribing();
+    try {
+      final result = await _service.transcribe(audioPath);
+      state = SttComplete(text: result.text, audioPath: audioPath);
+      AppLogger.info('STT complete: "${result.text}"', _tag);
+    } on SttException catch (e, st) {
+      AppLogger.error('STT failed (${e.code})', _tag, e, st);
+      state = SttError(code: e.code, message: e.message);
+    } catch (e, st) {
+      AppLogger.error('STT unexpected failure', _tag, e, st);
+      state = SttError(code: 'E007', message: e.toString());
+    }
+  }
+
+  void reset() {
+    state = const SttIdle();
+  }
+}

--- a/lib/screens/recording/widgets/recording_controls.dart
+++ b/lib/screens/recording/widgets/recording_controls.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../config/theme.dart';
 import '../../../core/constants/strings_tamil.dart';
@@ -17,7 +18,8 @@ class RecordingControls extends ConsumerWidget {
     return switch (recordingState) {
       RecordingIdle() => _buildRecordButton(notifier),
       RecordingActive() => _buildActiveControls(notifier),
-      RecordingComplete() => _buildCompleteControls(notifier),
+      RecordingComplete(:final filePath) =>
+        _buildCompleteControls(context, notifier, filePath),
       RecordingError(:final message) => _buildErrorControls(notifier, message),
     };
   }
@@ -77,14 +79,35 @@ class RecordingControls extends ConsumerWidget {
     );
   }
 
-  Widget _buildCompleteControls(RecordingNotifier notifier) {
-    return ElevatedButton.icon(
-      onPressed: notifier.reset,
-      icon: const Icon(Icons.mic),
-      label: const Text(TamilStrings.record),
-      style: ElevatedButton.styleFrom(
-        minimumSize: const Size(160, 48),
-      ),
+  Widget _buildCompleteControls(
+    BuildContext context,
+    RecordingNotifier notifier,
+    String filePath,
+  ) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ElevatedButton.icon(
+          onPressed: () {
+            final uri = Uri(
+              path: '/transcribe',
+              queryParameters: {'audioPath': filePath},
+            );
+            context.push(uri.toString());
+          },
+          icon: const Icon(Icons.auto_awesome),
+          label: const Text(TamilStrings.sttTranscribing),
+          style: ElevatedButton.styleFrom(
+            minimumSize: const Size(200, 56),
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextButton.icon(
+          onPressed: notifier.reset,
+          icon: const Icon(Icons.mic),
+          label: const Text(TamilStrings.retake),
+        ),
+      ],
     );
   }
 

--- a/lib/screens/transcription/transcribing_screen.dart
+++ b/lib/screens/transcription/transcribing_screen.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../config/theme.dart';
+import '../../core/constants/strings_tamil.dart';
+import '../../providers/stt_providers.dart';
+
+/// Progress screen shown while whisper.cpp transcribes the recorded audio.
+///
+/// Kicks off the transcription in [initState] and auto-navigates to the
+/// review screen on success. Shows a Tamil error + retry on failure.
+class TranscribingScreen extends ConsumerStatefulWidget {
+  const TranscribingScreen({required this.audioPath, super.key});
+
+  final String audioPath;
+
+  @override
+  ConsumerState<TranscribingScreen> createState() => _TranscribingScreenState();
+}
+
+class _TranscribingScreenState extends ConsumerState<TranscribingScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _start());
+  }
+
+  void _start() {
+    ref.read(sttNotifierProvider.notifier).transcribe(widget.audioPath);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<SttState>(sttNotifierProvider, (_, next) {
+      if (next is SttComplete) {
+        final uri = Uri(
+          path: '/review',
+          queryParameters: {
+            'audioPath': next.audioPath,
+            'text': next.text,
+          },
+        );
+        context.go(uri.toString());
+      }
+    });
+
+    final state = ref.watch(sttNotifierProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text(TamilStrings.sttTranscribing)),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Center(child: _buildBody(state)),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(SttState state) {
+    return switch (state) {
+      SttIdle() || SttLoadingModel() => const _Loading(
+          label: TamilStrings.sttModelLoading,
+        ),
+      SttTranscribing() => const _Loading(
+          label: TamilStrings.sttTranscribing,
+        ),
+      SttComplete() => const _Loading(
+          label: TamilStrings.sttTranscribing,
+        ),
+      SttError(:final code, :final message) =>
+        _Error(code: code, message: message, onRetry: _start),
+    };
+  }
+}
+
+class _Loading extends StatelessWidget {
+  const _Loading({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const SizedBox(
+          width: 64,
+          height: 64,
+          child: CircularProgressIndicator(
+            strokeWidth: 4,
+            color: NilamTheme.primaryGreen,
+          ),
+        ),
+        const SizedBox(height: 24),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.headlineSmall,
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}
+
+class _Error extends StatelessWidget {
+  const _Error({
+    required this.code,
+    required this.message,
+    required this.onRetry,
+  });
+
+  final String code;
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final friendly = _friendlyMessage(code);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Icon(Icons.error_outline,
+            size: 64, color: NilamTheme.redPrimary),
+        const SizedBox(height: 16),
+        Text(
+          friendly,
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                color: NilamTheme.redPrimary,
+              ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          '[$code] $message',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: NilamTheme.onSurfaceVariant,
+              ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 24),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            OutlinedButton.icon(
+              onPressed: () => context.go('/record'),
+              icon: const Icon(Icons.arrow_back),
+              label: const Text(TamilStrings.retake),
+            ),
+            const SizedBox(width: 16),
+            ElevatedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text(TamilStrings.retry),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  static String _friendlyMessage(String code) {
+    return switch (code) {
+      'E006' => TamilStrings.errorSttModelMissing,
+      'E007' => TamilStrings.errorSttFailed,
+      'E008' => TamilStrings.errorSttLowConfidence,
+      _ => TamilStrings.errorSttFailed,
+    };
+  }
+}

--- a/lib/screens/transcription/transcription_review_screen.dart
+++ b/lib/screens/transcription/transcription_review_screen.dart
@@ -1,0 +1,212 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../config/theme.dart';
+import '../../core/constants/strings_tamil.dart';
+import '../../core/logging/logger.dart';
+import '../../providers/database_providers.dart';
+import '../../services/database/daos/user_profile_dao.dart';
+import '../../services/database/models/query_history.dart';
+import '../../services/database/models/user_profile.dart';
+import '../../services/stt/stt_constants.dart';
+
+/// Editable review of the Whisper transcription.
+///
+/// The user can fix any wrong words, then confirm to persist the query to
+/// SQLite. Retake deletes the audio file and returns to the recording flow.
+class TranscriptionReviewScreen extends ConsumerStatefulWidget {
+  const TranscriptionReviewScreen({
+    required this.audioPath,
+    required this.initialText,
+    super.key,
+  });
+
+  final String audioPath;
+  final String initialText;
+
+  @override
+  ConsumerState<TranscriptionReviewScreen> createState() =>
+      _TranscriptionReviewScreenState();
+}
+
+class _TranscriptionReviewScreenState
+    extends ConsumerState<TranscriptionReviewScreen> {
+  static const _tag = 'TranscriptionReviewScreen';
+  static const _localUserPhoneHash = 'local_user_default';
+
+  late final TextEditingController _controller;
+  late final String _originalText;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialText);
+    _originalText = widget.initialText;
+    _controller.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _confirm() async {
+    if (_saving) return;
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+
+    setState(() => _saving = true);
+
+    try {
+      final userProfileDao = ref.read(userProfileDaoProvider);
+      final queryHistoryDao = ref.read(queryHistoryDaoProvider);
+
+      final userId = await _ensureLocalUser(userProfileDao);
+      final now = DateTime.now();
+      final confidence = text == _originalText
+          ? SttConstants.confidenceUnedited
+          : SttConstants.confidenceEdited;
+
+      final history = QueryHistory(
+        id: const Uuid().v4(),
+        userId: userId,
+        timestamp: now,
+        audioFilePath: widget.audioPath,
+        transcription: text,
+        transcriptionConfidence: confidence,
+        createdAt: now,
+        updatedAt: now,
+      );
+      await queryHistoryDao.insert(history);
+      AppLogger.info(
+        'Query saved (id=${history.id}, conf=$confidence)',
+        _tag,
+      );
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text(TamilStrings.transcriptionSaved)),
+      );
+      context.go('/');
+    } catch (e, st) {
+      AppLogger.error('Failed to save query history', _tag, e, st);
+      if (!mounted) return;
+      setState(() => _saving = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(TamilStrings.errorDatabase)),
+      );
+    }
+  }
+
+  Future<String> _ensureLocalUser(UserProfileDao dao) async {
+    final existing = await dao.getCurrent();
+    if (existing != null) return existing.id;
+
+    final now = DateTime.now();
+    final profile = UserProfile(
+      id: const Uuid().v4(),
+      phoneNumber: _localUserPhoneHash,
+      createdAt: now,
+      updatedAt: now,
+    );
+    await dao.insert(profile);
+    AppLogger.info('Bootstrapped local user ${profile.id}', _tag);
+    return profile.id;
+  }
+
+  Future<void> _retake() async {
+    try {
+      final file = File(widget.audioPath);
+      if (await file.exists()) {
+        await file.delete();
+        AppLogger.debug('Deleted audio file on retake', _tag);
+      }
+    } catch (e) {
+      AppLogger.warning('Could not delete audio file: $e', _tag);
+    }
+    if (!mounted) return;
+    context.go('/record');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final text = _controller.text.trim();
+    final canConfirm = text.isNotEmpty && !_saving;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text(TamilStrings.reviewTitle)),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                TamilStrings.reviewInstructions,
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  maxLines: null,
+                  expands: true,
+                  textAlignVertical: TextAlignVertical.top,
+                  style: Theme.of(context).textTheme.headlineSmall,
+                  decoration: InputDecoration(
+                    hintText: widget.initialText.isEmpty
+                        ? TamilStrings.transcriptionEmpty
+                        : null,
+                    contentPadding: const EdgeInsets.all(16),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: _saving ? null : _retake,
+                      icon: const Icon(Icons.mic),
+                      label: const Text(TamilStrings.retake),
+                      style: OutlinedButton.styleFrom(
+                        minimumSize: const Size(120, 56),
+                        side: const BorderSide(color: NilamTheme.outline),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: canConfirm ? _confirm : null,
+                      icon: _saving
+                          ? const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: Colors.white,
+                              ),
+                            )
+                          : const Icon(Icons.check),
+                      label: const Text(TamilStrings.confirm),
+                      style: ElevatedButton.styleFrom(
+                        minimumSize: const Size(120, 56),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/stt/stt_constants.dart
+++ b/lib/services/stt/stt_constants.dart
@@ -1,0 +1,27 @@
+/// Whisper STT configuration constants for NilamAI.
+///
+/// Uses the ggml-base-q8_0 model (~82 MB, INT8-quantized base Whisper).
+/// Bundled in the APK via `assets/models/` and copied to app documents on
+/// first launch by [WhisperModelLoader].
+class SttConstants {
+  SttConstants._();
+
+  // -- Model --
+  static const String modelAssetPath = 'assets/models/ggml-base-q8_0.bin';
+  static const String modelFileName = 'ggml-base-q8_0.bin';
+  static const String modelsSubDir = 'models';
+
+  // -- Language --
+  static const String language = 'ta';
+
+  // -- Review-based confidence --
+  static const double confidenceUnedited = 1.0;
+  static const double confidenceEdited = 0.5;
+
+  // -- Timeouts --
+  static const int maxTranscribeSeconds = 30;
+
+  // -- Validation --
+  static const String wavExtension = '.wav';
+  static const int minAudioFileBytes = 1024;
+}

--- a/lib/services/stt/whisper_model_loader.dart
+++ b/lib/services/stt/whisper_model_loader.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../../core/exceptions/app_exception.dart';
+import '../../core/logging/logger.dart';
+import 'stt_constants.dart';
+
+/// Returns the directory into which the model is copied.
+typedef AppDirProvider = Future<Directory> Function();
+
+/// Copies the bundled Whisper model from Flutter assets to a real filesystem
+/// path on first launch, so the native whisper.cpp layer can read it.
+///
+/// Subsequent launches detect the file and skip the copy.
+class WhisperModelLoader {
+  WhisperModelLoader({AssetBundle? assetBundle, AppDirProvider? appDirProvider})
+      : _assetBundle = assetBundle ?? rootBundle,
+        _appDirProvider = appDirProvider ?? getApplicationDocumentsDirectory;
+
+  static const _tag = 'WhisperModelLoader';
+
+  final AssetBundle _assetBundle;
+  final AppDirProvider _appDirProvider;
+  String? _cachedPath;
+
+  /// Ensures the model file is present on the local filesystem and returns
+  /// its absolute path. Throws [SttException.modelNotLoaded] on I/O error.
+  Future<String> ensureModelAvailable() async {
+    if (_cachedPath != null) return _cachedPath!;
+
+    try {
+      final appDir = await _appDirProvider();
+      final modelDir = Directory('${appDir.path}/${SttConstants.modelsSubDir}');
+      final target = File('${modelDir.path}/${SttConstants.modelFileName}');
+
+      if (await target.exists() && await target.length() > 0) {
+        AppLogger.debug('Model already present at ${target.path}', _tag);
+        _cachedPath = target.path;
+        return target.path;
+      }
+
+      if (!await modelDir.exists()) {
+        await modelDir.create(recursive: true);
+      }
+
+      AppLogger.info('Copying bundled Whisper model to ${target.path}', _tag);
+      final bytes = await _assetBundle.load(SttConstants.modelAssetPath);
+      await target.writeAsBytes(
+        bytes.buffer.asUint8List(bytes.offsetInBytes, bytes.lengthInBytes),
+        flush: true,
+      );
+      AppLogger.info(
+        'Model copy complete (${await target.length()} bytes)',
+        _tag,
+      );
+      _cachedPath = target.path;
+      return target.path;
+    } on SttException {
+      rethrow;
+    } catch (e, s) {
+      AppLogger.error('Failed to load Whisper model', _tag, e, s);
+      throw SttException.modelNotLoaded(originalError: e);
+    }
+  }
+
+  /// Test-only helper to reset the in-memory cache.
+  void resetCache() => _cachedPath = null;
+}

--- a/lib/services/stt/whisper_stt_service.dart
+++ b/lib/services/stt/whisper_stt_service.dart
@@ -1,0 +1,154 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:whisper_ggml/whisper_ggml.dart';
+
+import '../../core/exceptions/app_exception.dart';
+import '../../core/logging/logger.dart';
+import 'stt_constants.dart';
+import 'whisper_model_loader.dart';
+
+/// Minimal abstraction over the whisper.cpp backend so tests can substitute
+/// a fake without pulling in the native library.
+abstract class WhisperTranscriber {
+  Future<String> transcribe({
+    required String modelPath,
+    required String audioPath,
+    required String language,
+  });
+}
+
+/// Production transcriber delegating to the [Whisper] class from
+/// `whisper_ggml`. Uses [WhisperModel.base] as the enum tag — the actual
+/// weights are determined by [modelPath], not this field.
+class WhisperGgmlTranscriber implements WhisperTranscriber {
+  const WhisperGgmlTranscriber();
+
+  @override
+  Future<String> transcribe({
+    required String modelPath,
+    required String audioPath,
+    required String language,
+  }) async {
+    final whisper = Whisper(model: WhisperModel.base);
+    final response = await whisper.transcribe(
+      transcribeRequest: TranscribeRequest(
+        audio: audioPath,
+        language: language,
+        isTranslate: false,
+        isNoTimestamps: true,
+      ),
+      modelPath: modelPath,
+    );
+    return response.text;
+  }
+}
+
+/// Outcome of a successful transcription.
+class TranscriptionResult {
+  const TranscriptionResult({required this.text, required this.rawText});
+
+  /// Cleaned text (trimmed, whitespace collapsed) ready for the review UI.
+  final String text;
+
+  /// Raw output from whisper.cpp before normalization.
+  final String rawText;
+}
+
+/// High-level service that transcribes a Tamil WAV file to text using
+/// the locally bundled whisper.cpp model.
+class WhisperSttService {
+  WhisperSttService({
+    required WhisperModelLoader loader,
+    required WhisperTranscriber transcriber,
+  })  : _loader = loader,
+        _transcriber = transcriber;
+
+  static const _tag = 'WhisperSttService';
+
+  final WhisperModelLoader _loader;
+  final WhisperTranscriber _transcriber;
+
+  Future<TranscriptionResult> transcribe(String audioPath) async {
+    validateAudioFile(audioPath);
+
+    final String modelPath;
+    try {
+      modelPath = await _loader.ensureModelAvailable();
+    } on SttException {
+      rethrow;
+    } catch (e) {
+      throw SttException.modelNotLoaded(originalError: e);
+    }
+
+    final stopwatch = Stopwatch()..start();
+    try {
+      final raw = await _transcriber
+          .transcribe(
+            modelPath: modelPath,
+            audioPath: audioPath,
+            language: SttConstants.language,
+          )
+          .timeout(
+            const Duration(seconds: SttConstants.maxTranscribeSeconds),
+          );
+      stopwatch.stop();
+      AppLogger.info(
+        'Transcription complete in ${stopwatch.elapsedMilliseconds} ms',
+        _tag,
+      );
+      return TranscriptionResult(
+        text: normalizeTranscription(raw),
+        rawText: raw,
+      );
+    } on TimeoutException catch (e) {
+      throw SttException.transcriptionFailed(
+        'timeout after ${SttConstants.maxTranscribeSeconds}s',
+        originalError: e,
+      );
+    } on SttException {
+      rethrow;
+    } catch (e, s) {
+      AppLogger.error('Whisper transcription failed', _tag, e, s);
+      throw SttException.transcriptionFailed(
+        e.toString(),
+        originalError: e,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pure static helpers (unit-testable without the native layer)
+  // ---------------------------------------------------------------------------
+
+  /// Throws [SttException.transcriptionFailed] if the path is not a usable
+  /// WAV file (missing, wrong extension, empty, or too small).
+  static void validateAudioFile(String audioPath) {
+    if (audioPath.isEmpty) {
+      throw SttException.transcriptionFailed('audio path is empty');
+    }
+    if (!audioPath.toLowerCase().endsWith(SttConstants.wavExtension)) {
+      throw SttException.transcriptionFailed(
+        'unsupported audio format: $audioPath',
+      );
+    }
+    final file = File(audioPath);
+    if (!file.existsSync()) {
+      throw SttException.transcriptionFailed('audio file not found: $audioPath');
+    }
+    final size = file.lengthSync();
+    if (size < SttConstants.minAudioFileBytes) {
+      throw SttException.transcriptionFailed(
+        'audio file too small ($size bytes)',
+      );
+    }
+  }
+
+  /// Trims whitespace and collapses internal whitespace runs. Strips any
+  /// leading punctuation / whitespace-only output from whisper.
+  static String normalizeTranscription(String raw) {
+    if (raw.isEmpty) return '';
+    final collapsed = raw.replaceAll(RegExp(r'\s+'), ' ').trim();
+    return collapsed;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,12 +21,16 @@ dependencies:
   shared_preferences: ^2.2.3
   crypto: ^3.0.7
   path_provider: ^2.1.0
+  whisper_ggml: ^1.7.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
   sqflite_common_ffi: ^2.3.4+5
+  file: ^7.0.0
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/models/

--- a/scripts/fetch_model.ps1
+++ b/scripts/fetch_model.ps1
@@ -1,0 +1,25 @@
+#!/usr/bin/env pwsh
+# Fetches the Whisper ggml-base-q8_0 model for NilamAI.
+# Run once after cloning: pwsh scripts/fetch_model.ps1
+# Model: ~82 MB INT8-quantized base Whisper. Required for Phase 4 STT.
+
+$ErrorActionPreference = 'Stop'
+$modelUrl = 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-q8_0.bin'
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$targetDir = Join-Path $repoRoot 'assets\models'
+$targetFile = Join-Path $targetDir 'ggml-base-q8_0.bin'
+
+if (-not (Test-Path $targetDir)) {
+    New-Item -ItemType Directory -Path $targetDir | Out-Null
+}
+
+if ((Test-Path $targetFile) -and (Get-Item $targetFile).Length -gt 1MB) {
+    Write-Host "Model already present at $targetFile ($('{0:N1}' -f ((Get-Item $targetFile).Length/1MB)) MB)"
+    exit 0
+}
+
+Write-Host "Downloading ggml-base-q8_0.bin from Huggingface..."
+Invoke-WebRequest -Uri $modelUrl -OutFile $targetFile
+$sizeMb = '{0:N1}' -f ((Get-Item $targetFile).Length/1MB)
+Write-Host "Downloaded $sizeMb MB to $targetFile"

--- a/scripts/fetch_model.sh
+++ b/scripts/fetch_model.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Fetches the Whisper ggml-base-q8_0 model for NilamAI.
+# Run once after cloning: bash scripts/fetch_model.sh
+# Model: ~82 MB INT8-quantized base Whisper. Required for Phase 4 STT.
+
+set -euo pipefail
+
+MODEL_URL='https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-q8_0.bin'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TARGET_DIR="$REPO_ROOT/assets/models"
+TARGET_FILE="$TARGET_DIR/ggml-base-q8_0.bin"
+
+mkdir -p "$TARGET_DIR"
+
+if [ -f "$TARGET_FILE" ] && [ "$(stat -c%s "$TARGET_FILE" 2>/dev/null || stat -f%z "$TARGET_FILE")" -gt 1000000 ]; then
+    echo "Model already present at $TARGET_FILE"
+    exit 0
+fi
+
+echo "Downloading ggml-base-q8_0.bin from Huggingface..."
+if command -v curl >/dev/null; then
+    curl -L -o "$TARGET_FILE" "$MODEL_URL"
+elif command -v wget >/dev/null; then
+    wget -O "$TARGET_FILE" "$MODEL_URL"
+else
+    echo "Neither curl nor wget found — install one and retry." >&2
+    exit 1
+fi
+
+echo "Downloaded to $TARGET_FILE"

--- a/test/core/exceptions/stt_exception_test.dart
+++ b/test/core/exceptions/stt_exception_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+
+void main() {
+  group('SttException factories', () {
+    test('default constructor uses E002', () {
+      const e = SttException(message: 'generic failure');
+      expect(e.code, equals('E002'));
+    });
+
+    test('modelNotLoaded has code E006', () {
+      final e = SttException.modelNotLoaded();
+      expect(e.code, equals('E006'));
+      expect(e.message, contains('model'));
+    });
+
+    test('modelNotLoaded preserves originalError', () {
+      final original = FormatException('io error');
+      final e = SttException.modelNotLoaded(originalError: original);
+      expect(e.originalError, same(original));
+    });
+
+    test('transcriptionFailed has code E007 with detail', () {
+      final e = SttException.transcriptionFailed('timeout');
+      expect(e.code, equals('E007'));
+      expect(e.message, contains('timeout'));
+    });
+
+    test('lowConfidence has code E008 with formatted score', () {
+      final e = SttException.lowConfidence(0.72);
+      expect(e.code, equals('E008'));
+      expect(e.message, contains('0.72'));
+    });
+
+    test('toString includes the error code', () {
+      final e = SttException.modelNotLoaded();
+      expect(e.toString(), contains('E006'));
+    });
+  });
+}

--- a/test/providers/stt_providers_test.dart
+++ b/test/providers/stt_providers_test.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+import 'package:nilam_ai/providers/stt_providers.dart';
+import 'package:nilam_ai/services/stt/whisper_model_loader.dart';
+import 'package:nilam_ai/services/stt/whisper_stt_service.dart';
+
+class _FakeTranscriber implements WhisperTranscriber {
+  _FakeTranscriber({this.text = 'நெல் பயிர்', this.error});
+
+  final String text;
+  final Object? error;
+
+  @override
+  Future<String> transcribe({
+    required String modelPath,
+    required String audioPath,
+    required String language,
+  }) async {
+    if (error != null) throw error!;
+    return text;
+  }
+}
+
+class _FakeLoader extends WhisperModelLoader {
+  _FakeLoader({required this.modelPath, this.shouldThrow = false})
+      : super(appDirProvider: () async => Directory.systemTemp);
+
+  final String modelPath;
+  final bool shouldThrow;
+
+  @override
+  Future<String> ensureModelAvailable() async {
+    if (shouldThrow) throw SttException.modelNotLoaded();
+    return modelPath;
+  }
+}
+
+Future<File> _makeWavFile() async {
+  final dir = await Directory.systemTemp.createTemp('stt_provider_test_');
+  final file = File('${dir.path}/sample.wav')
+    ..writeAsBytesSync(List<int>.filled(8192, 0));
+  return file;
+}
+
+void main() {
+  group('SttNotifier state transitions', () {
+    late ProviderContainer container;
+    late File wav;
+
+    setUp(() async {
+      wav = await _makeWavFile();
+    });
+
+    tearDown(() async {
+      container.dispose();
+      final parent = wav.parent;
+      if (await parent.exists()) {
+        await parent.delete(recursive: true);
+      }
+    });
+
+    test('initial state is SttIdle', () {
+      container = ProviderContainer();
+      expect(container.read(sttNotifierProvider), isA<SttIdle>());
+    });
+
+    test(
+        'happy path transitions LoadingModel → Transcribing → Complete',
+        () async {
+      final fakeLoader = _FakeLoader(modelPath: '/fake/model.bin');
+      final fakeTranscriber = _FakeTranscriber(text: 'நெல் நோய்');
+
+      container = ProviderContainer(
+        overrides: [
+          whisperModelLoaderProvider.overrideWithValue(fakeLoader),
+          whisperTranscriberProvider.overrideWithValue(fakeTranscriber),
+        ],
+      );
+
+      final states = <SttState>[];
+      container.listen<SttState>(
+        sttNotifierProvider,
+        (_, next) => states.add(next),
+        fireImmediately: true,
+      );
+
+      await container.read(sttNotifierProvider.notifier).transcribe(wav.path);
+
+      expect(states.first, isA<SttIdle>());
+      expect(states.any((s) => s is SttLoadingModel), isTrue);
+      expect(states.any((s) => s is SttTranscribing), isTrue);
+      expect(states.last, isA<SttComplete>());
+
+      final complete = states.last as SttComplete;
+      expect(complete.text, equals('நெல் நோய்'));
+      expect(complete.audioPath, equals(wav.path));
+    });
+
+    test('model-load failure surfaces SttError with E006', () async {
+      final fakeLoader = _FakeLoader(
+        modelPath: '/unused',
+        shouldThrow: true,
+      );
+      final fakeTranscriber = _FakeTranscriber();
+
+      container = ProviderContainer(
+        overrides: [
+          whisperModelLoaderProvider.overrideWithValue(fakeLoader),
+          whisperTranscriberProvider.overrideWithValue(fakeTranscriber),
+        ],
+      );
+
+      await container.read(sttNotifierProvider.notifier).transcribe(wav.path);
+
+      final state = container.read(sttNotifierProvider);
+      expect(state, isA<SttError>());
+      expect((state as SttError).code, equals('E006'));
+    });
+
+    test('transcription failure surfaces SttError with E007', () async {
+      final fakeLoader = _FakeLoader(modelPath: '/fake/model.bin');
+      final fakeTranscriber = _FakeTranscriber(
+        error: Exception('native crash'),
+      );
+
+      container = ProviderContainer(
+        overrides: [
+          whisperModelLoaderProvider.overrideWithValue(fakeLoader),
+          whisperTranscriberProvider.overrideWithValue(fakeTranscriber),
+        ],
+      );
+
+      await container.read(sttNotifierProvider.notifier).transcribe(wav.path);
+
+      final state = container.read(sttNotifierProvider);
+      expect(state, isA<SttError>());
+      expect((state as SttError).code, equals('E007'));
+    });
+
+    test('reset returns state to SttIdle', () async {
+      final fakeLoader = _FakeLoader(modelPath: '/fake/model.bin');
+      final fakeTranscriber = _FakeTranscriber();
+
+      container = ProviderContainer(
+        overrides: [
+          whisperModelLoaderProvider.overrideWithValue(fakeLoader),
+          whisperTranscriberProvider.overrideWithValue(fakeTranscriber),
+        ],
+      );
+
+      await container.read(sttNotifierProvider.notifier).transcribe(wav.path);
+      expect(container.read(sttNotifierProvider), isA<SttComplete>());
+
+      container.read(sttNotifierProvider.notifier).reset();
+      expect(container.read(sttNotifierProvider), isA<SttIdle>());
+    });
+
+    test('exhaustive sealed switch compiles for every state', () {
+      String label(SttState s) => switch (s) {
+            SttIdle() => 'idle',
+            SttLoadingModel() => 'loading',
+            SttTranscribing() => 'transcribing',
+            SttComplete() => 'complete',
+            SttError() => 'error',
+          };
+
+      expect(label(const SttIdle()), 'idle');
+      expect(label(const SttLoadingModel()), 'loading');
+      expect(label(const SttTranscribing()), 'transcribing');
+      expect(
+        label(const SttComplete(text: 't', audioPath: 'a')),
+        'complete',
+      );
+      expect(
+        label(const SttError(code: 'E007', message: 'm')),
+        'error',
+      );
+    });
+  });
+}

--- a/test/screens/recording/recording_screen_test.dart
+++ b/test/screens/recording/recording_screen_test.dart
@@ -84,7 +84,8 @@ void main() {
       expect(find.text('0:45 / 2:00'), findsOneWidget);
     });
 
-    testWidgets('shows complete state with record button', (tester) async {
+    testWidgets('shows complete state with transcribe and retake buttons',
+        (tester) async {
       await tester.pumpWidget(_buildTestApp(
         const RecordingComplete(
           filePath: '/test/audio.wav',
@@ -94,7 +95,9 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text(TamilStrings.recordingComplete), findsOneWidget);
-      expect(find.text(TamilStrings.record), findsOneWidget);
+      // Phase 4: complete state hands off to the transcription flow.
+      expect(find.text(TamilStrings.sttTranscribing), findsOneWidget);
+      expect(find.text(TamilStrings.retake), findsOneWidget);
     });
 
     testWidgets('shows quality warning when present', (tester) async {

--- a/test/screens/transcription/transcribing_screen_test.dart
+++ b/test/screens/transcription/transcribing_screen_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nilam_ai/config/theme.dart';
+import 'package:nilam_ai/core/constants/strings_tamil.dart';
+import 'package:nilam_ai/providers/stt_providers.dart';
+import 'package:nilam_ai/screens/transcription/transcribing_screen.dart';
+
+/// Fake notifier driven entirely by the test — does not call any real service.
+///
+/// Tests call [emit] to push the next state and pump the widget.
+class _FakeSttNotifier extends SttNotifier {
+  _FakeSttNotifier(this._initialState);
+
+  final SttState _initialState;
+  int transcribeCalls = 0;
+  String? lastAudioPath;
+
+  @override
+  SttState build() => _initialState;
+
+  @override
+  Future<void> transcribe(String audioPath) async {
+    transcribeCalls += 1;
+    lastAudioPath = audioPath;
+  }
+
+  @override
+  void reset() {
+    state = const SttIdle();
+  }
+
+  void emit(SttState next) => state = next;
+}
+
+GoRouter _buildRouter({
+  required SttState initialState,
+  required String audioPath,
+  List<String>? visitedLocations,
+}) {
+  return GoRouter(
+    initialLocation: '/transcribe?audioPath=${Uri.encodeComponent(audioPath)}',
+    routes: [
+      GoRoute(
+        path: '/transcribe',
+        builder: (context, state) {
+          final path = state.uri.queryParameters['audioPath'] ?? '';
+          return TranscribingScreen(audioPath: path);
+        },
+      ),
+      GoRoute(
+        path: '/review',
+        builder: (context, state) {
+          visitedLocations?.add(state.uri.toString());
+          return const Scaffold(body: Text('REVIEW_SCREEN'));
+        },
+      ),
+      GoRoute(
+        path: '/record',
+        builder: (context, state) {
+          visitedLocations?.add(state.uri.toString());
+          return const Scaffold(body: Text('RECORD_SCREEN'));
+        },
+      ),
+    ],
+  );
+}
+
+Widget _buildApp({
+  required _FakeSttNotifier notifier,
+  required GoRouter router,
+}) {
+  return ProviderScope(
+    overrides: [
+      sttNotifierProvider.overrideWith(() => notifier),
+    ],
+    child: MaterialApp.router(
+      theme: NilamTheme.lightTheme,
+      routerConfig: router,
+    ),
+  );
+}
+
+void main() {
+  group('TranscribingScreen', () {
+    testWidgets('calls transcribe() on the notifier after initState',
+        (tester) async {
+      final notifier = _FakeSttNotifier(const SttIdle());
+      final router = _buildRouter(
+        initialState: const SttIdle(),
+        audioPath: '/tmp/test.wav',
+      );
+      await tester.pumpWidget(_buildApp(notifier: notifier, router: router));
+      await tester.pump(); // fire postFrameCallback (initState → _start)
+      await tester.pump();
+
+      expect(notifier.transcribeCalls, equals(1));
+      expect(notifier.lastAudioPath, equals('/tmp/test.wav'));
+    });
+
+    testWidgets('shows Tamil loading text while SttLoadingModel',
+        (tester) async {
+      final notifier = _FakeSttNotifier(const SttLoadingModel());
+      final router = _buildRouter(
+        initialState: const SttLoadingModel(),
+        audioPath: '/tmp/test.wav',
+      );
+      await tester.pumpWidget(_buildApp(notifier: notifier, router: router));
+      await tester.pump();
+
+      expect(find.text(TamilStrings.sttModelLoading), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('shows Tamil transcribing text while SttTranscribing',
+        (tester) async {
+      final notifier = _FakeSttNotifier(const SttTranscribing());
+      final router = _buildRouter(
+        initialState: const SttTranscribing(),
+        audioPath: '/tmp/test.wav',
+      );
+      await tester.pumpWidget(_buildApp(notifier: notifier, router: router));
+      await tester.pump();
+
+      expect(find.text(TamilStrings.sttTranscribing), findsWidgets);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('navigates to /review on SttComplete', (tester) async {
+      final notifier = _FakeSttNotifier(const SttTranscribing());
+      final visited = <String>[];
+      final router = _buildRouter(
+        initialState: const SttTranscribing(),
+        audioPath: '/tmp/test.wav',
+        visitedLocations: visited,
+      );
+
+      await tester.pumpWidget(_buildApp(notifier: notifier, router: router));
+      await tester.pump();
+      await tester.pump();
+
+      notifier.emit(
+        const SttComplete(text: 'நெல் பயிர்', audioPath: '/tmp/test.wav'),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('REVIEW_SCREEN'), findsOneWidget);
+      expect(visited, isNotEmpty);
+      expect(visited.first, contains('audioPath=%2Ftmp%2Ftest.wav'));
+      expect(visited.first, contains('text=%E0%AE%A8'));
+    });
+
+    testWidgets('shows Tamil error + retry + retake buttons on SttError',
+        (tester) async {
+      final notifier = _FakeSttNotifier(
+        const SttError(code: 'E006', message: 'model missing'),
+      );
+      final router = _buildRouter(
+        initialState: const SttError(code: 'E006', message: 'model missing'),
+        audioPath: '/tmp/test.wav',
+      );
+      await tester.pumpWidget(_buildApp(notifier: notifier, router: router));
+      await tester.pump();
+
+      expect(find.text(TamilStrings.errorSttModelMissing), findsOneWidget);
+      expect(find.text(TamilStrings.retry), findsOneWidget);
+      expect(find.text(TamilStrings.retake), findsOneWidget);
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    });
+
+    testWidgets('maps E007 to the transcription-failed message',
+        (tester) async {
+      final notifier = _FakeSttNotifier(
+        const SttError(code: 'E007', message: 'native crash'),
+      );
+      final router = _buildRouter(
+        initialState: const SttError(code: 'E007', message: 'native crash'),
+        audioPath: '/tmp/test.wav',
+      );
+      await tester.pumpWidget(_buildApp(notifier: notifier, router: router));
+      await tester.pump();
+
+      expect(find.text(TamilStrings.errorSttFailed), findsOneWidget);
+    });
+
+    testWidgets('retry button calls transcribe again', (tester) async {
+      final notifier = _FakeSttNotifier(
+        const SttError(code: 'E006', message: 'model missing'),
+      );
+      final router = _buildRouter(
+        initialState: const SttError(code: 'E006', message: 'model missing'),
+        audioPath: '/tmp/test.wav',
+      );
+      await tester.pumpWidget(_buildApp(notifier: notifier, router: router));
+      await tester.pump();
+      await tester.pump();
+
+      final before = notifier.transcribeCalls;
+      await tester.tap(find.text(TamilStrings.retry));
+      await tester.pump();
+
+      expect(notifier.transcribeCalls, equals(before + 1));
+    });
+  });
+}

--- a/test/screens/transcription/transcription_review_screen_test.dart
+++ b/test/screens/transcription/transcription_review_screen_test.dart
@@ -1,0 +1,278 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nilam_ai/config/theme.dart';
+import 'package:nilam_ai/core/constants/strings_tamil.dart';
+import 'package:nilam_ai/providers/database_providers.dart';
+import 'package:nilam_ai/screens/transcription/transcription_review_screen.dart';
+import 'package:nilam_ai/services/database/database_service.dart';
+import 'package:nilam_ai/services/stt/stt_constants.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+// Using GoRouter here (not a plain Navigator) because the screen calls
+// `context.go(...)` which is an extension defined on [BuildContext] by the
+// go_router package and requires a `GoRouter` to be present in the widget
+// tree.
+GoRouter _router({
+  required String audioPath,
+  required String initialText,
+  required List<String> visited,
+}) {
+  return GoRouter(
+    initialLocation: '/review?audioPath=${Uri.encodeComponent(audioPath)}'
+        '&text=${Uri.encodeComponent(initialText)}',
+    routes: [
+      GoRoute(
+        path: '/review',
+        builder: (context, state) => TranscriptionReviewScreen(
+          audioPath: state.uri.queryParameters['audioPath'] ?? '',
+          initialText: state.uri.queryParameters['text'] ?? '',
+        ),
+      ),
+      GoRoute(
+        path: '/',
+        builder: (context, state) {
+          visited.add('/');
+          return const Scaffold(body: Text('HOME_SCREEN'));
+        },
+      ),
+      GoRoute(
+        path: '/record',
+        builder: (context, state) {
+          visited.add('/record');
+          return const Scaffold(body: Text('RECORD_SCREEN'));
+        },
+      ),
+    ],
+  );
+}
+
+Widget _app({
+  required DatabaseService db,
+  required GoRouter router,
+}) {
+  return ProviderScope(
+    overrides: [
+      databaseServiceProvider.overrideWithValue(db),
+    ],
+    child: MaterialApp.router(
+      theme: NilamTheme.lightTheme,
+      routerConfig: router,
+    ),
+  );
+}
+
+/// `pumpAndSettle` hangs because of the blinking [TextField] cursor. Pump a
+/// bounded number of frames instead.
+Future<void> _pumpFrames(WidgetTester tester, [int frames = 3]) async {
+  for (var i = 0; i < frames; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late DatabaseService db;
+  late Directory tmp;
+  late File audio;
+
+  setUp(() async {
+    db = DatabaseService.create();
+    await db.initialize(path: inMemoryDatabasePath);
+    tmp = await Directory.systemTemp.createTemp('review_screen_test_');
+    audio = File('${tmp.path}/recording.wav');
+    await audio.writeAsBytes(List<int>.filled(4096, 0));
+  });
+
+  tearDown(() async {
+    await db.close();
+    try {
+      if (await tmp.exists()) {
+        await tmp.delete(recursive: true);
+      }
+    } catch (_) {
+      // Windows occasionally holds file handles briefly; ignore.
+    }
+  });
+
+  group('TranscriptionReviewScreen', () {
+    testWidgets('renders initial text and Tamil UI chrome', (tester) async {
+      final visited = <String>[];
+      final router = _router(
+        audioPath: audio.path,
+        initialText: 'நெல் பயிர்',
+        visited: visited,
+      );
+      await tester.pumpWidget(_app(db: db, router: router));
+      await _pumpFrames(tester);
+
+      expect(find.text(TamilStrings.reviewTitle), findsOneWidget);
+      expect(find.text(TamilStrings.reviewInstructions), findsOneWidget);
+      expect(find.text('நெல் பயிர்'), findsOneWidget);
+      expect(find.text(TamilStrings.confirm), findsOneWidget);
+      expect(find.text(TamilStrings.retake), findsOneWidget);
+    });
+
+    testWidgets('confirm button is disabled when text is empty',
+        (tester) async {
+      final visited = <String>[];
+      final router = _router(
+        audioPath: audio.path,
+        initialText: '',
+        visited: visited,
+      );
+      await tester.pumpWidget(_app(db: db, router: router));
+      await _pumpFrames(tester);
+
+      final confirmButton = tester.widget<ElevatedButton>(
+        find.byWidgetPredicate((w) => w is ElevatedButton),
+      );
+      expect(confirmButton.onPressed, isNull);
+    });
+
+    testWidgets('confirm button is enabled when text is non-empty',
+        (tester) async {
+      final visited = <String>[];
+      final router = _router(
+        audioPath: audio.path,
+        initialText: 'நெல் பயிர்',
+        visited: visited,
+      );
+      await tester.pumpWidget(_app(db: db, router: router));
+      await _pumpFrames(tester);
+
+      final confirmButton = tester.widget<ElevatedButton>(
+        find.byWidgetPredicate((w) => w is ElevatedButton),
+      );
+      expect(confirmButton.onPressed, isNotNull);
+    });
+
+    testWidgets(
+        'confirm with unedited text persists QueryHistory with confidence=1.0',
+        (tester) async {
+      final visited = <String>[];
+      final router = _router(
+        audioPath: audio.path,
+        initialText: 'நெல் பயிர்',
+        visited: visited,
+      );
+      await tester.pumpWidget(_app(db: db, router: router));
+      await _pumpFrames(tester);
+
+      await tester.tap(find.text(TamilStrings.confirm));
+      // Let the async DB writes complete.
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      });
+      await _pumpFrames(tester);
+
+      final user = await tester.runAsync(() => db.userProfileDao.getCurrent());
+      expect(user, isNotNull);
+      final rows = await tester
+          .runAsync(() => db.queryHistoryDao.getByUserId(user!.id));
+      expect(rows, hasLength(1));
+      expect(rows!.first.transcription, equals('நெல் பயிர்'));
+      expect(
+        rows.first.transcriptionConfidence,
+        equals(SttConstants.confidenceUnedited),
+      );
+      expect(rows.first.audioFilePath, equals(audio.path));
+    });
+
+    testWidgets(
+        'confirm with edited text persists QueryHistory with confidence=0.5',
+        (tester) async {
+      final visited = <String>[];
+      final router = _router(
+        audioPath: audio.path,
+        initialText: 'நெல் பயிர்',
+        visited: visited,
+      );
+      await tester.pumpWidget(_app(db: db, router: router));
+      await _pumpFrames(tester);
+
+      await tester.enterText(find.byType(TextField), 'நெல் நோய்');
+      await tester.pump();
+      await tester.tap(find.text(TamilStrings.confirm));
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      });
+      await _pumpFrames(tester);
+
+      final user = await tester.runAsync(() => db.userProfileDao.getCurrent());
+      expect(user, isNotNull);
+      final rows = await tester
+          .runAsync(() => db.queryHistoryDao.getByUserId(user!.id));
+      expect(rows, hasLength(1));
+      expect(rows!.first.transcription, equals('நெல் நோய்'));
+      expect(
+        rows.first.transcriptionConfidence,
+        equals(SttConstants.confidenceEdited),
+      );
+    });
+
+    testWidgets('confirm bootstraps a default user when none exists',
+        (tester) async {
+      final visited = <String>[];
+      final router = _router(
+        audioPath: audio.path,
+        initialText: 'நெல் பயிர்',
+        visited: visited,
+      );
+      await tester.pumpWidget(_app(db: db, router: router));
+      await _pumpFrames(tester);
+
+      expect(
+        await tester.runAsync(() => db.userProfileDao.getCurrent()),
+        isNull,
+      );
+
+      await tester.tap(find.text(TamilStrings.confirm));
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      });
+      await _pumpFrames(tester);
+
+      final user = await tester.runAsync(() => db.userProfileDao.getCurrent());
+      expect(user, isNotNull);
+      expect(user!.phoneNumber, equals('local_user_default'));
+    });
+
+    testWidgets('retake deletes the audio file and navigates to /record',
+        (tester) async {
+      final visited = <String>[];
+      final router = _router(
+        audioPath: audio.path,
+        initialText: 'நெல் பயிர்',
+        visited: visited,
+      );
+      await tester.pumpWidget(_app(db: db, router: router));
+      await _pumpFrames(tester);
+      expect(await tester.runAsync(() => audio.exists()), isTrue);
+
+      await tester.tap(find.text(TamilStrings.retake));
+      // `_retake` awaits real file I/O before calling `context.go`. Alternate
+      // `runAsync` (real time for I/O) with `pump` (drain microtasks so the
+      // handler's continuation can run, and GoRouter can rebuild). Several
+      // cycles are needed because each `await` inside `_retake` pauses the
+      // handler until the next microtask drain.
+      for (var i = 0; i < 4; i++) {
+        await tester.runAsync(() async {
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        });
+        await tester.pump();
+      }
+
+      expect(await tester.runAsync(() => audio.exists()), isFalse);
+      expect(visited, contains('/record'));
+      expect(find.text('RECORD_SCREEN'), findsOneWidget);
+    });
+  });
+}

--- a/test/services/stt/stt_constants_test.dart
+++ b/test/services/stt/stt_constants_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/services/stt/stt_constants.dart';
+
+void main() {
+  group('SttConstants', () {
+    test('model asset path matches bundle location', () {
+      expect(
+        SttConstants.modelAssetPath,
+        equals('assets/models/ggml-base-q8_0.bin'),
+      );
+    });
+
+    test('model filename is ggml-base-q8_0.bin', () {
+      expect(SttConstants.modelFileName, equals('ggml-base-q8_0.bin'));
+    });
+
+    test('language is Tamil', () {
+      expect(SttConstants.language, equals('ta'));
+    });
+
+    test('confidence for unedited transcription is 1.0', () {
+      expect(SttConstants.confidenceUnedited, equals(1.0));
+    });
+
+    test('confidence for edited transcription is 0.5', () {
+      expect(SttConstants.confidenceEdited, equals(0.5));
+    });
+
+    test('edited confidence is strictly lower than unedited', () {
+      expect(
+        SttConstants.confidenceEdited,
+        lessThan(SttConstants.confidenceUnedited),
+      );
+    });
+
+    test('wav extension is dotted', () {
+      expect(SttConstants.wavExtension, equals('.wav'));
+    });
+
+    test('max transcribe timeout is bounded', () {
+      expect(SttConstants.maxTranscribeSeconds, greaterThan(0));
+      expect(SttConstants.maxTranscribeSeconds, lessThanOrEqualTo(120));
+    });
+
+    test('min audio file bytes is non-trivial', () {
+      expect(SttConstants.minAudioFileBytes, greaterThan(0));
+    });
+  });
+}

--- a/test/services/stt/whisper_model_loader_test.dart
+++ b/test/services/stt/whisper_model_loader_test.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+import 'package:nilam_ai/services/stt/stt_constants.dart';
+import 'package:nilam_ai/services/stt/whisper_model_loader.dart';
+
+/// Fake AssetBundle that returns pre-seeded bytes for a given asset path.
+class _FakeAssetBundle extends CachingAssetBundle {
+  _FakeAssetBundle(this._assets);
+
+  final Map<String, Uint8List> _assets;
+  int loadCalls = 0;
+
+  @override
+  Future<ByteData> load(String key) async {
+    loadCalls += 1;
+    final bytes = _assets[key];
+    if (bytes == null) {
+      throw FlutterError('Asset not found: $key');
+    }
+    return ByteData.sublistView(bytes);
+  }
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async {
+    throw UnimplementedError();
+  }
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('model_loader_test_');
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Future<Directory> fakeAppDir() async => tempDir;
+
+  group('WhisperModelLoader.ensureModelAvailable', () {
+    test('copies bundled asset on first call and returns file path', () async {
+      final payload = Uint8List.fromList(
+        List<int>.generate(2048, (i) => i % 256),
+      );
+      final bundle = _FakeAssetBundle({
+        SttConstants.modelAssetPath: payload,
+      });
+      final loader = WhisperModelLoader(
+        assetBundle: bundle,
+        appDirProvider: fakeAppDir,
+      );
+
+      final path = await loader.ensureModelAvailable();
+
+      expect(path, endsWith(SttConstants.modelFileName));
+      final file = File(path);
+      expect(await file.exists(), isTrue);
+      expect(await file.length(), equals(payload.length));
+      expect(bundle.loadCalls, equals(1));
+    });
+
+    test('skips copy on subsequent calls when model already cached', () async {
+      final payload = Uint8List.fromList(List<int>.filled(1024, 7));
+      final bundle = _FakeAssetBundle({
+        SttConstants.modelAssetPath: payload,
+      });
+      final loader = WhisperModelLoader(
+        assetBundle: bundle,
+        appDirProvider: fakeAppDir,
+      );
+
+      final p1 = await loader.ensureModelAvailable();
+      final p2 = await loader.ensureModelAvailable();
+
+      expect(p1, equals(p2));
+      expect(bundle.loadCalls, equals(1));
+    });
+
+    test('skips copy when file already on disk (no cache) but not in memory',
+        () async {
+      final payload = Uint8List.fromList(List<int>.filled(1024, 3));
+      final bundle = _FakeAssetBundle({
+        SttConstants.modelAssetPath: payload,
+      });
+      final loader = WhisperModelLoader(
+        assetBundle: bundle,
+        appDirProvider: fakeAppDir,
+      );
+
+      await loader.ensureModelAvailable();
+      loader.resetCache();
+      await loader.ensureModelAvailable();
+
+      expect(bundle.loadCalls, equals(1)); // second call used on-disk file
+    });
+
+    test('throws SttException.modelNotLoaded when asset is missing', () async {
+      final bundle = _FakeAssetBundle(const {});
+      final loader = WhisperModelLoader(
+        assetBundle: bundle,
+        appDirProvider: fakeAppDir,
+      );
+
+      await expectLater(
+        loader.ensureModelAvailable(),
+        throwsA(
+          isA<SttException>().having((e) => e.code, 'code', 'E006'),
+        ),
+      );
+    });
+
+    test('creates the models subdirectory if missing', () async {
+      final payload = Uint8List.fromList(List<int>.filled(1024, 1));
+      final bundle = _FakeAssetBundle({
+        SttConstants.modelAssetPath: payload,
+      });
+      final loader = WhisperModelLoader(
+        assetBundle: bundle,
+        appDirProvider: fakeAppDir,
+      );
+
+      expect(
+        await Directory('${tempDir.path}/${SttConstants.modelsSubDir}')
+            .exists(),
+        isFalse,
+      );
+
+      await loader.ensureModelAvailable();
+
+      expect(
+        await Directory('${tempDir.path}/${SttConstants.modelsSubDir}')
+            .exists(),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/services/stt/whisper_stt_service_test.dart
+++ b/test/services/stt/whisper_stt_service_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+import 'package:nilam_ai/services/stt/whisper_stt_service.dart';
+
+void main() {
+  group('WhisperSttService.normalizeTranscription', () {
+    test('returns empty string unchanged', () {
+      expect(WhisperSttService.normalizeTranscription(''), equals(''));
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(
+        WhisperSttService.normalizeTranscription('  நெல் பயிர்  '),
+        equals('நெல் பயிர்'),
+      );
+    });
+
+    test('collapses multiple internal spaces', () {
+      expect(
+        WhisperSttService.normalizeTranscription('நெல்\t பயிர்\n\nநோய்'),
+        equals('நெல் பயிர் நோய்'),
+      );
+    });
+
+    test('preserves Tamil characters', () {
+      const input = 'நெல் பயிரில் மஞ்சள் புள்ளிகள் உள்ளன';
+      expect(
+        WhisperSttService.normalizeTranscription(input),
+        equals(input),
+      );
+    });
+  });
+
+  group('WhisperSttService.validateAudioFile', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('stt_test_');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('throws SttException (E007) when path is empty', () {
+      expect(
+        () => WhisperSttService.validateAudioFile(''),
+        throwsA(
+          isA<SttException>().having((e) => e.code, 'code', 'E007'),
+        ),
+      );
+    });
+
+    test('throws SttException (E007) when extension is wrong', () async {
+      final file = File('${tempDir.path}/audio.mp3')
+        ..writeAsBytesSync(List.filled(2048, 0));
+      expect(
+        () => WhisperSttService.validateAudioFile(file.path),
+        throwsA(
+          isA<SttException>().having((e) => e.code, 'code', 'E007'),
+        ),
+      );
+    });
+
+    test('throws SttException (E007) when file missing', () {
+      expect(
+        () => WhisperSttService.validateAudioFile(
+            '${tempDir.path}/does_not_exist.wav'),
+        throwsA(
+          isA<SttException>().having((e) => e.code, 'code', 'E007'),
+        ),
+      );
+    });
+
+    test('throws SttException (E007) when file is too small', () async {
+      final file = File('${tempDir.path}/tiny.wav')
+        ..writeAsBytesSync([1, 2, 3]);
+      expect(
+        () => WhisperSttService.validateAudioFile(file.path),
+        throwsA(
+          isA<SttException>().having((e) => e.code, 'code', 'E007'),
+        ),
+      );
+    });
+
+    test('accepts a valid .wav file of sufficient size', () async {
+      final file = File('${tempDir.path}/ok.wav')
+        ..writeAsBytesSync(List.filled(4096, 0));
+      expect(
+        () => WhisperSttService.validateAudioFile(file.path),
+        returnsNormally,
+      );
+    });
+
+    test('accepts uppercase .WAV extension', () async {
+      final file = File('${tempDir.path}/ok.WAV')
+        ..writeAsBytesSync(List.filled(4096, 0));
+      expect(
+        () => WhisperSttService.validateAudioFile(file.path),
+        returnsNormally,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds offline Tamil speech-to-text using `whisper_ggml` with the INT8-quantized `ggml-base-q8_0` model (78 MB, bundled as a Flutter asset and copied to app storage on first run).
- Recording → progress screen (model load → transcribing) → always-editable review screen → confirm persists a `QueryHistory` with confidence **1.0** (unedited) or **0.5** (edited).
- Retake deletes the audio file and returns to the record screen.

## What changed
- New STT service layer: `WhisperModelLoader`, `WhisperSttService`, `SttConstants`, Riverpod state machine in `stt_providers.dart` (Idle → LoadingModel → Transcribing → Complete / Error).
- New screens: `TranscribingScreen` (progress + error recovery), `TranscriptionReviewScreen` (edit + confirm + retake).
- New error codes E006/E007/E008 for model-missing / STT-failed / low-confidence paths.
- Model bundled via `pubspec.yaml` assets; fetched by `scripts/fetch_model.ps1` / `scripts/fetch_model.sh` (not committed to git — too large).

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 157/157 passing
- [x] Unit tests: STT constants, model loader, STT service, STT providers, STT exception mapping
- [x] Widget tests: `TranscribingScreen` (7), `TranscriptionReviewScreen` (7)
- [x] Installed debug APK on Moto G34 5G (Android 15) and launched successfully
- [ ] End-to-end manual smoke on device: record Tamil → confirm → verify history

🤖 Generated with [Claude Code](https://claude.com/claude-code)