### PR TITLE
Add Phase 5a: Basic UI screens (Home, Response, History, Settings)

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-import '../core/constants/strings_tamil.dart';
+import '../screens/history/history_screen.dart';
+import '../screens/home/home_screen.dart';
 import '../screens/recording/recording_screen.dart';
+import '../screens/response/response_screen.dart';
+import '../screens/settings/settings_screen.dart';
 import '../screens/transcription/transcribing_screen.dart';
 import '../screens/transcription/transcription_review_screen.dart';
 
@@ -43,52 +46,28 @@ final GoRouter appRouter = GoRouter(
         );
       },
     ),
+    GoRoute(
+      path: '/response/:queryId',
+      name: 'response',
+      builder: (BuildContext context, GoRouterState state) {
+        return ResponseScreen(
+          queryId: state.pathParameters['queryId']!,
+        );
+      },
+    ),
+    GoRoute(
+      path: '/history',
+      name: 'history',
+      builder: (BuildContext context, GoRouterState state) {
+        return const HistoryScreen();
+      },
+    ),
+    GoRoute(
+      path: '/settings',
+      name: 'settings',
+      builder: (BuildContext context, GoRouterState state) {
+        return const SettingsScreen();
+      },
+    ),
   ],
 );
-
-/// Temporary home screen for Phase 1 verification.
-/// Will be replaced by the actual home screen in Phase 5a.
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('NilamAI'),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.agriculture,
-              size: 64,
-              color: theme.colorScheme.primary,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              TamilStrings.appName,
-              style: theme.textTheme.headlineLarge?.copyWith(
-                color: theme.colorScheme.primary,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              '${TamilStrings.greeting} ${TamilStrings.appTagline}',
-              style: theme.textTheme.bodyLarge?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => context.push('/record'),
-        tooltip: TamilStrings.record,
-        child: const Icon(Icons.mic),
-      ),
-    );
-  }
-}

--- a/lib/core/constants/strings_tamil.dart
+++ b/lib/core/constants/strings_tamil.dart
@@ -83,4 +83,44 @@ class TamilStrings {
       'உரை மாற்றம் தோல்வி. மீண்டும் முயற்சிக்கவும்';
   static const String errorSttLowConfidence =
       'உரை தெளிவாக இல்லை. திருத்தவும்';
+
+  // -- Home --
+  static const String homeTitle = 'நிலம்AI';
+  static const String recentQuestions = 'சமீபத்திய கேள்விகள்';
+  static const String noRecentQuestions = 'இன்னும் கேள்விகள் இல்லை';
+  static const String askQuestionCta = '🎤 கேள்வி கேளுங்கள்';
+
+  // -- Response --
+  static const String responseTitle = 'பதில்';
+  static const String yourQuestion = 'உங்கள் கேள்வி';
+  static const String aiResponse = 'AI பதில்';
+  static const String responsePlaceholder = '🌾 AI பதில் விரைவில் வரும்...';
+  static const String audioComingSoon = '🔊 விரைவில் வரும்';
+  static const String helpful = '👍 பயனுள்ளது';
+  static const String notHelpful = '👎 பயனில்லை';
+  static const String ratingSaved = 'மதிப்பீடு சேமிக்கப்பட்டது';
+  static const String goHome = '🔙 முகப்பு';
+  static const String playSpeed = 'வேகம்';
+  static const String queryNotFound = 'கேள்வி கிடைக்கவில்லை';
+
+  // -- History --
+  static const String historyTitle = 'வரலாறு';
+  static const String searchHint = 'தேடுக...';
+  static const String historyEmpty = '📜 இன்னும் கேள்விகள் இல்லை';
+  static const String deleteConfirmTitle = 'நீக்க வேண்டுமா?';
+  static const String deleteConfirmMessage =
+      'இந்த கேள்வியை நிரந்தரமாக நீக்க விரும்புகிறீர்களா?';
+  static const String deleted = 'நீக்கப்பட்டது';
+
+  // -- Settings --
+  static const String settingsTitle = 'அமைப்புகள்';
+  static const String ttsSpeedLabel = 'குரல் வேகம்';
+  static const String notificationsLabel = 'அறிவிப்புகள்';
+  static const String clearHistoryLabel = '🗑️ வரலாற்றை அழி';
+  static const String clearHistoryConfirmTitle = 'வரலாற்றை அழிக்க வேண்டுமா?';
+  static const String clearHistoryConfirmMessage =
+      'அனைத்து கேள்விகளும் நிரந்தரமாக நீக்கப்படும்.';
+  static const String historyCleared = 'வரலாறு அழிக்கப்பட்டது';
+  static const String aboutLabel = 'பற்றி';
+  static const String versionLabel = 'பதிப்பு';
 }

--- a/lib/core/utils/relative_time.dart
+++ b/lib/core/utils/relative_time.dart
@@ -1,0 +1,16 @@
+import 'package:intl/intl.dart';
+
+/// Format a past [DateTime] as a Tamil relative-time phrase.
+///
+/// Buckets: now (<60s), N minutes, N hours, N days, then absolute date.
+/// Pass [now] for deterministic tests.
+String formatRelativeTamil(DateTime when, {DateTime? now}) {
+  final reference = now ?? DateTime.now();
+  final diff = reference.difference(when);
+
+  if (diff.inSeconds < 60) return 'இப்போது';
+  if (diff.inMinutes < 60) return '${diff.inMinutes} நிமிடம் முன்பு';
+  if (diff.inHours < 24) return '${diff.inHours} மணி நேரம் முன்பு';
+  if (diff.inDays < 7) return '${diff.inDays} நாள் முன்பு';
+  return DateFormat('dd/MM/yyyy').format(when);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'config/routes.dart';
 import 'config/theme.dart';
 import 'core/logging/logger.dart';
 import 'providers/database_providers.dart';
+import 'providers/settings_providers.dart';
 import 'services/database/database_service.dart';
 
 void main() async {
@@ -17,10 +19,13 @@ void main() async {
     AppLogger.error('Database initialization failed', 'main', e);
   }
 
+  final prefs = await SharedPreferences.getInstance();
+
   runApp(
     ProviderScope(
       overrides: [
         databaseServiceProvider.overrideWithValue(dbService),
+        sharedPreferencesProvider.overrideWithValue(prefs),
       ],
       child: const NilamAIApp(),
     ),

--- a/lib/providers/database_providers.dart
+++ b/lib/providers/database_providers.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/database/database_service.dart';
 import '../services/database/daos/user_profile_dao.dart';
 import '../services/database/daos/query_history_dao.dart';
+import '../services/database/models/query_history.dart';
 
 /// Provides the initialized [DatabaseService].
 ///
@@ -29,4 +30,47 @@ final userProfileDaoProvider = Provider<UserProfileDao>((ref) {
 /// Convenience provider for [QueryHistoryDao].
 final queryHistoryDaoProvider = Provider<QueryHistoryDao>((ref) {
   return ref.watch(databaseServiceProvider).queryHistoryDao;
+});
+
+/// Loads a single [QueryHistory] by id. Returns `null` if not found.
+final queryByIdProvider =
+    FutureProvider.family<QueryHistory?, String>((ref, id) async {
+  return ref.watch(queryHistoryDaoProvider).getById(id);
+});
+
+/// Loads up to 5 most recent queries for the given user — used by the Home
+/// screen recent-questions list.
+final recentQueriesProvider =
+    FutureProvider.family<List<QueryHistory>, String>((ref, userId) async {
+  return ref.watch(queryHistoryDaoProvider).getByUserId(userId, limit: 5);
+});
+
+/// Lookup parameters for [historyQueriesProvider].
+class HistoryQuery {
+  const HistoryQuery({required this.userId, this.keyword});
+
+  final String userId;
+  final String? keyword;
+
+  @override
+  bool operator ==(Object other) =>
+      other is HistoryQuery &&
+      other.userId == userId &&
+      other.keyword == keyword;
+
+  @override
+  int get hashCode => Object.hash(userId, keyword);
+}
+
+/// Loads the History screen's query list — applies search if a keyword is set,
+/// otherwise returns the user's queries (newest first, max 50).
+final historyQueriesProvider =
+    FutureProvider.family<List<QueryHistory>, HistoryQuery>(
+        (ref, query) async {
+  final dao = ref.watch(queryHistoryDaoProvider);
+  final keyword = query.keyword?.trim();
+  if (keyword != null && keyword.isNotEmpty) {
+    return dao.searchByKeyword(keyword, userId: query.userId, limit: 50);
+  }
+  return dao.getByUserId(query.userId, limit: 50);
 });

--- a/lib/providers/settings_providers.dart
+++ b/lib/providers/settings_providers.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SettingsState {
+  const SettingsState({
+    required this.ttsSpeed,
+    required this.notificationsEnabled,
+  });
+
+  final double ttsSpeed;
+  final bool notificationsEnabled;
+
+  SettingsState copyWith({double? ttsSpeed, bool? notificationsEnabled}) {
+    return SettingsState(
+      ttsSpeed: ttsSpeed ?? this.ttsSpeed,
+      notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
+    );
+  }
+}
+
+class _Keys {
+  static const ttsSpeed = 'tts_speed';
+  static const notificationsEnabled = 'notifications_enabled';
+}
+
+const double _defaultTtsSpeed = 1.0;
+const bool _defaultNotifications = true;
+
+/// Holds the SharedPreferences instance. Override in main() after async init.
+final sharedPreferencesProvider = Provider<SharedPreferences>((ref) {
+  throw UnimplementedError(
+    'sharedPreferencesProvider must be overridden with a SharedPreferences instance',
+  );
+});
+
+class SettingsNotifier extends Notifier<SettingsState> {
+  @override
+  SettingsState build() {
+    final prefs = ref.read(sharedPreferencesProvider);
+    return SettingsState(
+      ttsSpeed: prefs.getDouble(_Keys.ttsSpeed) ?? _defaultTtsSpeed,
+      notificationsEnabled:
+          prefs.getBool(_Keys.notificationsEnabled) ?? _defaultNotifications,
+    );
+  }
+
+  Future<void> setTtsSpeed(double speed) async {
+    final prefs = ref.read(sharedPreferencesProvider);
+    await prefs.setDouble(_Keys.ttsSpeed, speed);
+    state = state.copyWith(ttsSpeed: speed);
+  }
+
+  Future<void> setNotificationsEnabled(bool enabled) async {
+    final prefs = ref.read(sharedPreferencesProvider);
+    await prefs.setBool(_Keys.notificationsEnabled, enabled);
+    state = state.copyWith(notificationsEnabled: enabled);
+  }
+}
+
+final settingsProvider =
+    NotifierProvider<SettingsNotifier, SettingsState>(SettingsNotifier.new);

--- a/lib/providers/user_providers.dart
+++ b/lib/providers/user_providers.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../core/logging/logger.dart';
+import '../services/database/models/user_profile.dart';
+import 'database_providers.dart';
+
+const String _localUserPhoneHash = 'local_user_default';
+
+/// Resolves the current local user id, bootstrapping a default profile if none
+/// exists. Single-user MVP — first launch creates the row, subsequent launches
+/// reuse it.
+final currentUserIdProvider = FutureProvider<String>((ref) async {
+  const tag = 'currentUserIdProvider';
+  final dao = ref.read(userProfileDaoProvider);
+
+  final existing = await dao.getCurrent();
+  if (existing != null) return existing.id;
+
+  final now = DateTime.now();
+  final profile = UserProfile(
+    id: const Uuid().v4(),
+    phoneNumber: _localUserPhoneHash,
+    createdAt: now,
+    updatedAt: now,
+  );
+  await dao.insert(profile);
+  AppLogger.info('Bootstrapped local user ${profile.id}', tag);
+  return profile.id;
+});

--- a/lib/screens/history/history_screen.dart
+++ b/lib/screens/history/history_screen.dart
@@ -1,0 +1,204 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/constants/strings_tamil.dart';
+import '../../core/utils/relative_time.dart';
+import '../../providers/database_providers.dart';
+import '../../providers/user_providers.dart';
+import '../../services/database/models/query_history.dart';
+
+class HistoryScreen extends ConsumerStatefulWidget {
+  const HistoryScreen({super.key});
+
+  @override
+  ConsumerState<HistoryScreen> createState() => _HistoryScreenState();
+}
+
+class _HistoryScreenState extends ConsumerState<HistoryScreen> {
+  final _searchController = TextEditingController();
+  Timer? _debounce;
+  String? _keyword;
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String value) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 300), () {
+      if (!mounted) return;
+      setState(() => _keyword = value.trim().isEmpty ? null : value.trim());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asyncUserId = ref.watch(currentUserIdProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text(TamilStrings.historyTitle)),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              TextField(
+                controller: _searchController,
+                onChanged: _onSearchChanged,
+                decoration: InputDecoration(
+                  hintText: TamilStrings.searchHint,
+                  prefixIcon: const Icon(Icons.search),
+                  suffixIcon: _searchController.text.isEmpty
+                      ? null
+                      : IconButton(
+                          tooltip: TamilStrings.cancel,
+                          icon: const Icon(Icons.clear),
+                          onPressed: () {
+                            _searchController.clear();
+                            _onSearchChanged('');
+                          },
+                        ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Expanded(
+                child: asyncUserId.when(
+                  data: (userId) =>
+                      _HistoryList(userId: userId, keyword: _keyword),
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (_, _) =>
+                      Center(child: Text(TamilStrings.errorDatabase)),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HistoryList extends ConsumerWidget {
+  const _HistoryList({required this.userId, required this.keyword});
+
+  final String userId;
+  final String? keyword;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final query = HistoryQuery(userId: userId, keyword: keyword);
+    final asyncQueries = ref.watch(historyQueriesProvider(query));
+
+    return RefreshIndicator(
+      onRefresh: () async => ref.invalidate(historyQueriesProvider(query)),
+      child: asyncQueries.when(
+        data: (queries) {
+          if (queries.isEmpty) return const _EmptyHistory();
+          return ListView.separated(
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: queries.length,
+            separatorBuilder: (_, _) => const Divider(height: 1),
+            itemBuilder: (_, i) => _HistoryTile(
+              query: queries[i],
+              onDeleted: () =>
+                  ref.invalidate(historyQueriesProvider(query)),
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => Center(child: Text(TamilStrings.errorDatabase)),
+      ),
+    );
+  }
+}
+
+class _EmptyHistory extends StatelessWidget {
+  const _EmptyHistory();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        SizedBox(
+          height: MediaQuery.of(context).size.height * 0.5,
+          child: Center(
+            child: Text(
+              TamilStrings.historyEmpty,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _HistoryTile extends ConsumerWidget {
+  const _HistoryTile({required this.query, required this.onDeleted});
+
+  final QueryHistory query;
+  final VoidCallback onDeleted;
+
+  Future<void> _confirmDelete(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text(TamilStrings.deleteConfirmTitle),
+        content: const Text(TamilStrings.deleteConfirmMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text(TamilStrings.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text(TamilStrings.delete),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await ref.read(queryHistoryDaoProvider).delete(query.id);
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text(TamilStrings.deleted)),
+    );
+    onDeleted();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      title: Text(
+        query.transcription,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(formatRelativeTamil(query.timestamp)),
+      trailing: _ratingIcon(query.userRating),
+      onTap: () => context.push('/response/${query.id}'),
+      onLongPress: () => _confirmDelete(context, ref),
+    );
+  }
+
+  Widget? _ratingIcon(String? rating) {
+    if (rating == 'thumbs_up') {
+      return const Icon(Icons.thumb_up, size: 20);
+    }
+    if (rating == 'thumbs_down') {
+      return const Icon(Icons.thumb_down, size: 20);
+    }
+    return null;
+  }
+}

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/constants/strings_tamil.dart';
+import '../../core/utils/relative_time.dart';
+import '../../providers/database_providers.dart';
+import '../../providers/user_providers.dart';
+import '../../services/database/models/query_history.dart';
+
+/// App entry screen — large CTA to ask a new question and a list of the
+/// 5 most recent past queries.
+class HomeScreen extends ConsumerWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final asyncUserId = ref.watch(currentUserIdProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(TamilStrings.homeTitle),
+        actions: [
+          IconButton(
+            tooltip: TamilStrings.history,
+            onPressed: () => context.push('/history'),
+            icon: const Icon(Icons.history),
+          ),
+          IconButton(
+            tooltip: TamilStrings.settings,
+            onPressed: () => context.push('/settings'),
+            icon: const Icon(Icons.settings),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                TamilStrings.appTagline,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                height: 72,
+                child: ElevatedButton.icon(
+                  onPressed: () => context.push('/record'),
+                  icon: const Icon(Icons.mic, size: 28),
+                  label: const Text(
+                    TamilStrings.askQuestionCta,
+                    style: TextStyle(fontSize: 18),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 32),
+              Text(
+                TamilStrings.recentQuestions,
+                style: theme.textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 8),
+              Expanded(
+                child: asyncUserId.when(
+                  data: (userId) => _RecentList(userId: userId),
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (e, _) =>
+                      Center(child: Text(TamilStrings.errorDatabase)),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RecentList extends ConsumerWidget {
+  const _RecentList({required this.userId});
+
+  final String userId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncRecent = ref.watch(recentQueriesProvider(userId));
+    return asyncRecent.when(
+      data: (queries) {
+        if (queries.isEmpty) return const _EmptyRecent();
+        return ListView.separated(
+          itemCount: queries.length,
+          separatorBuilder: (_, _) => const Divider(height: 1),
+          itemBuilder: (_, i) => _QueryTile(query: queries[i]),
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text(TamilStrings.errorDatabase)),
+    );
+  }
+}
+
+class _EmptyRecent extends StatelessWidget {
+  const _EmptyRecent();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.agriculture,
+            size: 56,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            TamilStrings.noRecentQuestions,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _QueryTile extends StatelessWidget {
+  const _QueryTile({required this.query});
+
+  final QueryHistory query;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(
+        query.transcription,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(formatRelativeTamil(query.timestamp)),
+      trailing: _ratingIcon(query.userRating),
+      onTap: () => context.push('/response/${query.id}'),
+    );
+  }
+
+  Widget? _ratingIcon(String? rating) {
+    if (rating == 'thumbs_up') {
+      return const Icon(Icons.thumb_up, size: 20);
+    }
+    if (rating == 'thumbs_down') {
+      return const Icon(Icons.thumb_down, size: 20);
+    }
+    return null;
+  }
+}

--- a/lib/screens/response/response_screen.dart
+++ b/lib/screens/response/response_screen.dart
@@ -1,0 +1,283 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../config/theme.dart';
+import '../../core/constants/strings_tamil.dart';
+import '../../core/logging/logger.dart';
+import '../../providers/database_providers.dart';
+import '../../services/database/models/query_history.dart';
+
+const String _ratingThumbsUp = 'thumbs_up';
+const String _ratingThumbsDown = 'thumbs_down';
+
+/// Displays the saved query, the (eventual) AI response, and rating controls.
+///
+/// Audio playback is stubbed (Phase 7, see #16). Gemma response field stays
+/// null until Phase 6 wires the LLM (#15) — placeholder in the meantime.
+class ResponseScreen extends ConsumerWidget {
+  const ResponseScreen({required this.queryId, super.key});
+
+  final String queryId;
+
+  static const _tag = 'ResponseScreen';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncQuery = ref.watch(queryByIdProvider(queryId));
+    return Scaffold(
+      appBar: AppBar(title: const Text(TamilStrings.responseTitle)),
+      body: SafeArea(
+        child: asyncQuery.when(
+          data: (query) {
+            if (query == null) {
+              return const Center(child: Text(TamilStrings.queryNotFound));
+            }
+            return _ResponseBody(query: query);
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, st) {
+            AppLogger.error('Failed to load query $queryId', _tag, e, st);
+            return Center(child: Text(TamilStrings.errorDatabase));
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _ResponseBody extends ConsumerStatefulWidget {
+  const _ResponseBody({required this.query});
+
+  final QueryHistory query;
+
+  @override
+  ConsumerState<_ResponseBody> createState() => _ResponseBodyState();
+}
+
+class _ResponseBodyState extends ConsumerState<_ResponseBody> {
+  static const _tag = 'ResponseScreen';
+  bool _saving = false;
+
+  Future<void> _setRating(String tappedRating) async {
+    if (_saving) return;
+    final current = widget.query.userRating;
+    final newRating = current == tappedRating ? null : tappedRating;
+
+    setState(() => _saving = true);
+    try {
+      final dao = ref.read(queryHistoryDaoProvider);
+      final q = widget.query;
+      await dao.update(
+        QueryHistory(
+          id: q.id,
+          userId: q.userId,
+          timestamp: q.timestamp,
+          audioFilePath: q.audioFilePath,
+          transcription: q.transcription,
+          transcriptionConfidence: q.transcriptionConfidence,
+          gemmaPrompt: q.gemmaPrompt,
+          gemmaResponse: q.gemmaResponse,
+          gemmaLatencyMs: q.gemmaLatencyMs,
+          userRating: newRating,
+          createdAt: q.createdAt,
+          updatedAt: DateTime.now(),
+        ),
+      );
+      ref.invalidate(queryByIdProvider(widget.query.id));
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text(TamilStrings.ratingSaved)),
+      );
+    } catch (e, st) {
+      AppLogger.error('Failed to save rating', _tag, e, st);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(TamilStrings.errorDatabase)),
+      );
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final query = widget.query;
+    final response = query.gemmaResponse;
+    final hasResponse = response != null && response.isNotEmpty;
+    final rating = query.userRating;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    TamilStrings.yourQuestion,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    query.transcription,
+                    style: theme.textTheme.headlineSmall,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    TamilStrings.aiResponse,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  // TODO(#15): once Phase 6 (#6) wires Gemma, the placeholder
+                  // branch goes away — `hasResponse` should always be true.
+                  Text(
+                    hasResponse ? response : TamilStrings.responsePlaceholder,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      fontStyle:
+                          hasResponse ? FontStyle.normal : FontStyle.italic,
+                      color: hasResponse
+                          ? theme.colorScheme.onSurface
+                          : theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          _AudioControls(),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: _RatingButton(
+                  label: TamilStrings.helpful,
+                  selected: rating == _ratingThumbsUp,
+                  onPressed: _saving
+                      ? null
+                      : () => _setRating(_ratingThumbsUp),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _RatingButton(
+                  label: TamilStrings.notHelpful,
+                  selected: rating == _ratingThumbsDown,
+                  onPressed: _saving
+                      ? null
+                      : () => _setRating(_ratingThumbsDown),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          OutlinedButton(
+            onPressed: () => context.go('/'),
+            style: OutlinedButton.styleFrom(
+              minimumSize: const Size(double.infinity, 56),
+              side: const BorderSide(color: NilamTheme.outline),
+            ),
+            child: const Text(TamilStrings.goHome),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// TODO(#16): Phase 7 (#7) wires real TTS — replace `onPressed: null` with
+// play/pause handlers, swap the static "1.0x" label for a Dropdown bound to
+// `settingsProvider.ttsSpeed`, and drop the `audioComingSoon` caption.
+class _AudioControls extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                IconButton(
+                  tooltip: TamilStrings.play,
+                  onPressed: null,
+                  iconSize: 36,
+                  icon: const Icon(Icons.play_arrow),
+                ),
+                const SizedBox(width: 8),
+                IconButton(
+                  tooltip: TamilStrings.stop,
+                  onPressed: null,
+                  iconSize: 36,
+                  icon: const Icon(Icons.pause),
+                ),
+                const SizedBox(width: 16),
+                Text(
+                  '${TamilStrings.playSpeed}: 1.0x',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              TamilStrings.audioComingSoon,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RatingButton extends StatelessWidget {
+  const _RatingButton({
+    required this.label,
+    required this.selected,
+    required this.onPressed,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = ButtonStyle(
+      minimumSize: WidgetStateProperty.all(const Size(double.infinity, 56)),
+    );
+    return selected
+        ? FilledButton(onPressed: onPressed, style: style, child: Text(label))
+        : FilledButton.tonal(
+            onPressed: onPressed,
+            style: style,
+            child: Text(label),
+          );
+  }
+}

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../../core/constants/strings_tamil.dart';
+import '../../core/logging/logger.dart';
+import '../../providers/database_providers.dart';
+import '../../providers/settings_providers.dart';
+import '../../providers/user_providers.dart';
+
+class SettingsScreen extends ConsumerWidget {
+  const SettingsScreen({super.key});
+
+  static const _tag = 'SettingsScreen';
+
+  Future<void> _confirmClearHistory(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text(TamilStrings.clearHistoryConfirmTitle),
+        content: const Text(TamilStrings.clearHistoryConfirmMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text(TamilStrings.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text(TamilStrings.delete),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    try {
+      final userId = await ref.read(currentUserIdProvider.future);
+      await ref.read(queryHistoryDaoProvider).deleteAllForUser(userId);
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text(TamilStrings.historyCleared)),
+      );
+    } catch (e, st) {
+      AppLogger.error('Failed to clear history', _tag, e, st);
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(TamilStrings.errorDatabase)),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(settingsProvider);
+    final notifier = ref.read(settingsProvider.notifier);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text(TamilStrings.settingsTitle)),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          children: [
+            ListTile(
+              title: const Text(TamilStrings.ttsSpeedLabel),
+              subtitle: Slider(
+                min: 0.8,
+                max: 1.2,
+                divisions: 2,
+                value: settings.ttsSpeed,
+                label: '${settings.ttsSpeed.toStringAsFixed(1)}x',
+                onChanged: notifier.setTtsSpeed,
+              ),
+              trailing: Text('${settings.ttsSpeed.toStringAsFixed(1)}x'),
+            ),
+            const Divider(height: 1),
+            SwitchListTile(
+              title: const Text(TamilStrings.notificationsLabel),
+              value: settings.notificationsEnabled,
+              onChanged: notifier.setNotificationsEnabled,
+            ),
+            const Divider(height: 1),
+            ListTile(
+              leading: const Icon(Icons.delete_outline),
+              title: const Text(TamilStrings.clearHistoryLabel),
+              onTap: () => _confirmClearHistory(context, ref),
+            ),
+            const Divider(height: 1),
+            const _AboutTile(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AboutTile extends StatelessWidget {
+  const _AboutTile();
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<PackageInfo>(
+      future: PackageInfo.fromPlatform(),
+      builder: (context, snap) {
+        final info = snap.data;
+        final subtitle = info == null
+            ? '...'
+            : '${TamilStrings.versionLabel}: ${info.version}+${info.buildNumber}';
+        return ListTile(
+          leading: const Icon(Icons.info_outline),
+          title: const Text(TamilStrings.aboutLabel),
+          subtitle: Text(subtitle),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/transcription/transcription_review_screen.dart
+++ b/lib/screens/transcription/transcription_review_screen.dart
@@ -9,9 +9,8 @@ import '../../config/theme.dart';
 import '../../core/constants/strings_tamil.dart';
 import '../../core/logging/logger.dart';
 import '../../providers/database_providers.dart';
-import '../../services/database/daos/user_profile_dao.dart';
+import '../../providers/user_providers.dart';
 import '../../services/database/models/query_history.dart';
-import '../../services/database/models/user_profile.dart';
 import '../../services/stt/stt_constants.dart';
 
 /// Editable review of the Whisper transcription.
@@ -36,7 +35,6 @@ class TranscriptionReviewScreen extends ConsumerStatefulWidget {
 class _TranscriptionReviewScreenState
     extends ConsumerState<TranscriptionReviewScreen> {
   static const _tag = 'TranscriptionReviewScreen';
-  static const _localUserPhoneHash = 'local_user_default';
 
   late final TextEditingController _controller;
   late final String _originalText;
@@ -64,10 +62,9 @@ class _TranscriptionReviewScreenState
     setState(() => _saving = true);
 
     try {
-      final userProfileDao = ref.read(userProfileDaoProvider);
       final queryHistoryDao = ref.read(queryHistoryDaoProvider);
 
-      final userId = await _ensureLocalUser(userProfileDao);
+      final userId = await ref.read(currentUserIdProvider.future);
       final now = DateTime.now();
       final confidence = text == _originalText
           ? SttConstants.confidenceUnedited
@@ -93,7 +90,10 @@ class _TranscriptionReviewScreenState
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text(TamilStrings.transcriptionSaved)),
       );
-      context.go('/');
+      // TODO(#15): Phase 6 (#6) should kick off Gemma here (or before nav)
+      // and update QueryHistory.gemmaResponse so the Response screen flips
+      // from placeholder to the real answer.
+      context.go('/response/${history.id}');
     } catch (e, st) {
       AppLogger.error('Failed to save query history', _tag, e, st);
       if (!mounted) return;
@@ -102,22 +102,6 @@ class _TranscriptionReviewScreenState
         SnackBar(content: Text(TamilStrings.errorDatabase)),
       );
     }
-  }
-
-  Future<String> _ensureLocalUser(UserProfileDao dao) async {
-    final existing = await dao.getCurrent();
-    if (existing != null) return existing.id;
-
-    final now = DateTime.now();
-    final profile = UserProfile(
-      id: const Uuid().v4(),
-      phoneNumber: _localUserPhoneHash,
-      createdAt: now,
-      updatedAt: now,
-    );
-    await dao.insert(profile);
-    AppLogger.info('Bootstrapped local user ${profile.id}', _tag);
-    return profile.id;
   }
 
   Future<void> _retake() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,9 +22,12 @@ dependencies:
   crypto: ^3.0.7
   path_provider: ^2.1.0
   whisper_ggml: ^1.7.0
+  package_info_plus: ^8.0.0
 
 dev_dependencies:
   flutter_test:
+    sdk: flutter
+  integration_test:
     sdk: flutter
   flutter_lints: ^6.0.0
   sqflite_common_ffi: ^2.3.4+5

--- a/test/core/utils/relative_time_test.dart
+++ b/test/core/utils/relative_time_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/core/utils/relative_time.dart';
+
+void main() {
+  final now = DateTime(2026, 4, 19, 12, 0, 0);
+
+  group('formatRelativeTamil', () {
+    test('<60s returns "now"', () {
+      expect(
+        formatRelativeTamil(now.subtract(const Duration(seconds: 30)),
+            now: now),
+        equals('இப்போது'),
+      );
+    });
+
+    test('minutes bucket', () {
+      expect(
+        formatRelativeTamil(now.subtract(const Duration(minutes: 5)), now: now),
+        equals('5 நிமிடம் முன்பு'),
+      );
+    });
+
+    test('hours bucket', () {
+      expect(
+        formatRelativeTamil(now.subtract(const Duration(hours: 4)), now: now),
+        equals('4 மணி நேரம் முன்பு'),
+      );
+    });
+
+    test('days bucket', () {
+      expect(
+        formatRelativeTamil(now.subtract(const Duration(days: 3)), now: now),
+        equals('3 நாள் முன்பு'),
+      );
+    });
+
+    test('>=7d falls back to absolute date', () {
+      final old = DateTime(2025, 12, 1);
+      expect(formatRelativeTamil(old, now: now), equals('01/12/2025'));
+    });
+  });
+}

--- a/test/providers/settings_providers_test.dart
+++ b/test/providers/settings_providers_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/providers/settings_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<ProviderContainer> makeContainer(
+      Map<String, Object> initialPrefs) async {
+    SharedPreferences.setMockInitialValues(initialPrefs);
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('SettingsNotifier', () {
+    test('uses defaults when prefs are empty', () async {
+      final container = await makeContainer({});
+      final state = container.read(settingsProvider);
+      expect(state.ttsSpeed, equals(1.0));
+      expect(state.notificationsEnabled, isTrue);
+    });
+
+    test('reads stored values from prefs', () async {
+      final container = await makeContainer({
+        'tts_speed': 1.2,
+        'notifications_enabled': false,
+      });
+      final state = container.read(settingsProvider);
+      expect(state.ttsSpeed, equals(1.2));
+      expect(state.notificationsEnabled, isFalse);
+    });
+
+    test('setTtsSpeed updates state and persists', () async {
+      final container = await makeContainer({});
+      await container.read(settingsProvider.notifier).setTtsSpeed(0.8);
+      expect(container.read(settingsProvider).ttsSpeed, equals(0.8));
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getDouble('tts_speed'), equals(0.8));
+    });
+
+    test('setNotificationsEnabled updates state and persists', () async {
+      final container = await makeContainer({});
+      await container
+          .read(settingsProvider.notifier)
+          .setNotificationsEnabled(false);
+      expect(container.read(settingsProvider).notificationsEnabled, isFalse);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('notifications_enabled'), isFalse);
+    });
+  });
+}

--- a/test/providers/user_providers_test.dart
+++ b/test/providers/user_providers_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/providers/database_providers.dart';
+import 'package:nilam_ai/providers/user_providers.dart';
+import 'package:nilam_ai/services/database/database_service.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  Future<(ProviderContainer, DatabaseService)> makeContainer() async {
+    final db = DatabaseService.create();
+    await db.initialize(path: inMemoryDatabasePath);
+    final container = ProviderContainer(
+      overrides: [databaseServiceProvider.overrideWithValue(db)],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await db.close();
+    });
+    return (container, db);
+  }
+
+  group('currentUserIdProvider', () {
+    test('bootstraps a default user when none exists', () async {
+      final (container, db) = await makeContainer();
+      expect(await db.userProfileDao.getCurrent(), isNull);
+
+      final id = await container.read(currentUserIdProvider.future);
+
+      final user = await db.userProfileDao.getCurrent();
+      expect(user, isNotNull);
+      expect(user!.id, equals(id));
+      expect(user.phoneNumber, equals('local_user_default'));
+    });
+
+    test('returns the existing user id on subsequent reads', () async {
+      final (container, _) = await makeContainer();
+      final first = await container.read(currentUserIdProvider.future);
+      container.invalidate(currentUserIdProvider);
+      final second = await container.read(currentUserIdProvider.future);
+      expect(second, equals(first));
+    });
+  });
+}

--- a/test/screens/history/history_screen_test.dart
+++ b/test/screens/history/history_screen_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nilam_ai/core/constants/strings_tamil.dart';
+import 'package:nilam_ai/providers/database_providers.dart';
+import 'package:nilam_ai/screens/history/history_screen.dart';
+import 'package:nilam_ai/services/database/database_service.dart';
+import 'package:nilam_ai/services/database/models/query_history.dart';
+import 'package:nilam_ai/services/database/models/user_profile.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:uuid/uuid.dart';
+
+GoRouter _router() => GoRouter(
+      initialLocation: '/history',
+      routes: [
+        GoRoute(path: '/history', builder: (_, _) => const HistoryScreen()),
+        GoRoute(
+          path: '/response/:queryId',
+          builder: (_, _) => const Scaffold(body: Text('RESPONSE_SCREEN')),
+        ),
+      ],
+    );
+
+Widget _app({required DatabaseService db}) {
+  return ProviderScope(
+    overrides: [databaseServiceProvider.overrideWithValue(db)],
+    child: MaterialApp.router(routerConfig: _router()),
+  );
+}
+
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 6; i++) {
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pump();
+  }
+}
+
+Future<String> _seedUserAndQueries(
+  DatabaseService db, {
+  List<String> texts = const [],
+}) async {
+  final userId = const Uuid().v4();
+  final now = DateTime.now();
+  await db.userProfileDao.insert(UserProfile(
+    id: userId,
+    phoneNumber: 'local_user_default',
+    createdAt: now,
+    updatedAt: now,
+  ));
+  for (var i = 0; i < texts.length; i++) {
+    await db.queryHistoryDao.insert(QueryHistory(
+      id: const Uuid().v4(),
+      userId: userId,
+      timestamp: now.subtract(Duration(minutes: i)),
+      transcription: texts[i],
+      transcriptionConfidence: 1.0,
+      createdAt: now,
+      updatedAt: now,
+    ));
+  }
+  return userId;
+}
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late DatabaseService db;
+
+  setUp(() async {
+    db = DatabaseService.create();
+    await db.initialize(path: inMemoryDatabasePath);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('HistoryScreen', () {
+    testWidgets('renders empty state when no queries', (tester) async {
+      await tester.pumpWidget(_app(db: db));
+      await _settle(tester);
+
+      expect(find.text(TamilStrings.historyEmpty), findsOneWidget);
+    });
+
+    testWidgets('renders the query list', (tester) async {
+      await tester.runAsync(() => _seedUserAndQueries(
+            db,
+            texts: ['நெல் பயிர்', 'மண் வளம்', 'பூச்சி நாசினி'],
+          ));
+      await tester.pumpWidget(_app(db: db));
+      await _settle(tester);
+
+      expect(find.text('நெல் பயிர்'), findsOneWidget);
+      expect(find.text('மண் வளம்'), findsOneWidget);
+      expect(find.text('பூச்சி நாசினி'), findsOneWidget);
+    });
+
+    testWidgets('search filters results', (tester) async {
+      await tester.runAsync(() => _seedUserAndQueries(
+            db,
+            texts: ['நெல் பயிர்', 'மண் வளம்'],
+          ));
+      await tester.pumpWidget(_app(db: db));
+      await _settle(tester);
+
+      await tester.enterText(find.byType(TextField), 'நெல்');
+      // Advance the fake clock past the 300 ms debounce.
+      await tester.pump(const Duration(milliseconds: 400));
+      await _settle(tester);
+
+      expect(find.text('நெல் பயிர்'), findsOneWidget);
+      expect(find.text('மண் வளம்'), findsNothing);
+    });
+
+    testWidgets('long-press opens delete dialog and confirm deletes',
+        (tester) async {
+      await tester.runAsync(
+          () => _seedUserAndQueries(db, texts: ['நெல் பயிர்']));
+      await tester.pumpWidget(_app(db: db));
+      await _settle(tester);
+
+      await tester.longPress(find.text('நெல் பயிர்'));
+      await _settle(tester);
+
+      expect(find.text(TamilStrings.deleteConfirmTitle), findsOneWidget);
+
+      await tester.tap(find.text(TamilStrings.delete));
+      await _settle(tester);
+
+      expect(find.text('நெல் பயிர்'), findsNothing);
+      expect(find.text(TamilStrings.historyEmpty), findsOneWidget);
+    });
+  });
+}

--- a/test/screens/home/home_screen_test.dart
+++ b/test/screens/home/home_screen_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nilam_ai/core/constants/strings_tamil.dart';
+import 'package:nilam_ai/providers/database_providers.dart';
+import 'package:nilam_ai/screens/home/home_screen.dart';
+import 'package:nilam_ai/services/database/database_service.dart';
+import 'package:nilam_ai/services/database/models/query_history.dart';
+import 'package:nilam_ai/services/database/models/user_profile.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:uuid/uuid.dart';
+
+GoRouter _router(List<String> visited) => GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(path: '/', builder: (_, _) => const HomeScreen()),
+        GoRoute(
+          path: '/record',
+          builder: (_, _) {
+            visited.add('/record');
+            return const Scaffold(body: Text('RECORD_SCREEN'));
+          },
+        ),
+        GoRoute(
+          path: '/history',
+          builder: (_, _) {
+            visited.add('/history');
+            return const Scaffold(body: Text('HISTORY_SCREEN'));
+          },
+        ),
+        GoRoute(
+          path: '/settings',
+          builder: (_, _) {
+            visited.add('/settings');
+            return const Scaffold(body: Text('SETTINGS_SCREEN'));
+          },
+        ),
+        GoRoute(
+          path: '/response/:queryId',
+          builder: (_, state) {
+            visited.add('/response/${state.pathParameters['queryId']}');
+            return const Scaffold(body: Text('RESPONSE_SCREEN'));
+          },
+        ),
+      ],
+    );
+
+Widget _app({
+  required DatabaseService db,
+  required GoRouter router,
+}) {
+  return ProviderScope(
+    overrides: [databaseServiceProvider.overrideWithValue(db)],
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 5; i++) {
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+    });
+    await tester.pump();
+  }
+}
+
+UserProfile _seedUser(String id, DateTime now) => UserProfile(
+      id: id,
+      phoneNumber: 'local_user_default',
+      createdAt: now,
+      updatedAt: now,
+    );
+
+QueryHistory _seedQuery(String userId, String text, DateTime ts) =>
+    QueryHistory(
+      id: const Uuid().v4(),
+      userId: userId,
+      timestamp: ts,
+      transcription: text,
+      transcriptionConfidence: 1.0,
+      createdAt: ts,
+      updatedAt: ts,
+    );
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late DatabaseService db;
+
+  setUp(() async {
+    db = DatabaseService.create();
+    await db.initialize(path: inMemoryDatabasePath);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('HomeScreen', () {
+    testWidgets('renders tagline, CTA, and AppBar action icons',
+        (tester) async {
+      final visited = <String>[];
+      await tester.pumpWidget(_app(db: db, router: _router(visited)));
+      await _settle(tester);
+
+      expect(find.text(TamilStrings.appTagline), findsOneWidget);
+      expect(find.text(TamilStrings.askQuestionCta), findsOneWidget);
+      expect(find.text(TamilStrings.recentQuestions), findsOneWidget);
+      expect(find.byIcon(Icons.history), findsOneWidget);
+      expect(find.byIcon(Icons.settings), findsOneWidget);
+    });
+
+    testWidgets('shows empty state when no recent queries', (tester) async {
+      final visited = <String>[];
+      await tester.pumpWidget(_app(db: db, router: _router(visited)));
+      await _settle(tester);
+
+      expect(find.text(TamilStrings.noRecentQuestions), findsOneWidget);
+    });
+
+    testWidgets('renders recent queries when present', (tester) async {
+      final visited = <String>[];
+      await tester.runAsync(() async {
+        final userId = const Uuid().v4();
+        final now = DateTime.now();
+        await db.userProfileDao.insert(_seedUser(userId, now));
+        await db.queryHistoryDao
+            .insert(_seedQuery(userId, 'நெல் பயிர் கேள்வி', now));
+        await db.queryHistoryDao.insert(_seedQuery(
+          userId,
+          'மண் வளம்',
+          now.subtract(const Duration(hours: 2)),
+        ));
+      });
+
+      await tester.pumpWidget(_app(db: db, router: _router(visited)));
+      await _settle(tester);
+
+      expect(find.text('நெல் பயிர் கேள்வி'), findsOneWidget);
+      expect(find.text('மண் வளம்'), findsOneWidget);
+    });
+
+    testWidgets('tapping CTA navigates to /record', (tester) async {
+      final visited = <String>[];
+      await tester.pumpWidget(_app(db: db, router: _router(visited)));
+      await _settle(tester);
+
+      await tester.tap(find.text(TamilStrings.askQuestionCta));
+      await _settle(tester);
+
+      expect(visited, contains('/record'));
+    });
+
+    testWidgets('tapping settings icon navigates to /settings',
+        (tester) async {
+      final visited = <String>[];
+      await tester.pumpWidget(_app(db: db, router: _router(visited)));
+      await _settle(tester);
+
+      await tester.tap(find.byIcon(Icons.settings));
+      await _settle(tester);
+
+      expect(visited, contains('/settings'));
+    });
+  });
+}

--- a/test/screens/response/response_screen_test.dart
+++ b/test/screens/response/response_screen_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nilam_ai/core/constants/strings_tamil.dart';
+import 'package:nilam_ai/providers/database_providers.dart';
+import 'package:nilam_ai/screens/response/response_screen.dart';
+import 'package:nilam_ai/services/database/database_service.dart';
+import 'package:nilam_ai/services/database/models/query_history.dart';
+import 'package:nilam_ai/services/database/models/user_profile.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:uuid/uuid.dart';
+
+GoRouter _router(String queryId, List<String> visited) => GoRouter(
+      initialLocation: '/response/$queryId',
+      routes: [
+        GoRoute(
+          path: '/response/:queryId',
+          builder: (_, state) =>
+              ResponseScreen(queryId: state.pathParameters['queryId']!),
+        ),
+        GoRoute(
+          path: '/',
+          builder: (_, _) {
+            visited.add('/');
+            return const Scaffold(body: Text('HOME_SCREEN'));
+          },
+        ),
+      ],
+    );
+
+Widget _app({required DatabaseService db, required GoRouter router}) {
+  return ProviderScope(
+    overrides: [databaseServiceProvider.overrideWithValue(db)],
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 5; i++) {
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+    });
+    await tester.pump();
+  }
+}
+
+Future<String> _seedQuery(
+  DatabaseService db, {
+  String? gemmaResponse,
+  String? userRating,
+}) async {
+  final userId = const Uuid().v4();
+  final now = DateTime.now();
+  await db.userProfileDao.insert(UserProfile(
+    id: userId,
+    phoneNumber: 'local_user_default',
+    createdAt: now,
+    updatedAt: now,
+  ));
+  final id = const Uuid().v4();
+  await db.queryHistoryDao.insert(QueryHistory(
+    id: id,
+    userId: userId,
+    timestamp: now,
+    transcription: 'நெல் நோய் என்ன?',
+    transcriptionConfidence: 1.0,
+    gemmaResponse: gemmaResponse,
+    userRating: userRating,
+    createdAt: now,
+    updatedAt: now,
+  ));
+  return id;
+}
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late DatabaseService db;
+
+  setUp(() async {
+    db = DatabaseService.create();
+    await db.initialize(path: inMemoryDatabasePath);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('ResponseScreen', () {
+    testWidgets('renders transcription and placeholder when response is null',
+        (tester) async {
+      final id = await tester.runAsync(() => _seedQuery(db));
+      await tester.pumpWidget(_app(db: db, router: _router(id!, [])));
+      await _settle(tester);
+
+      expect(find.text('நெல் நோய் என்ன?'), findsOneWidget);
+      expect(find.text(TamilStrings.responsePlaceholder), findsOneWidget);
+      expect(find.text(TamilStrings.audioComingSoon), findsOneWidget);
+    });
+
+    testWidgets('renders gemma response when present', (tester) async {
+      final id = await tester.runAsync(
+        () => _seedQuery(db, gemmaResponse: 'செப்பு சல்பேட் தெளிக்கவும்'),
+      );
+      await tester.pumpWidget(_app(db: db, router: _router(id!, [])));
+      await _settle(tester);
+
+      expect(find.text('செப்பு சல்பேட் தெளிக்கவும்'), findsOneWidget);
+      expect(find.text(TamilStrings.responsePlaceholder), findsNothing);
+    });
+
+    testWidgets('audio play/pause icons are disabled', (tester) async {
+      final id = await tester.runAsync(() => _seedQuery(db));
+      await tester.pumpWidget(_app(db: db, router: _router(id!, [])));
+      await _settle(tester);
+
+      final playButton = tester.widget<IconButton>(
+        find.ancestor(
+          of: find.byIcon(Icons.play_arrow),
+          matching: find.byType(IconButton),
+        ),
+      );
+      expect(playButton.onPressed, isNull);
+    });
+
+    testWidgets('tapping helpful sets userRating to thumbs_up',
+        (tester) async {
+      final id = await tester.runAsync(() => _seedQuery(db));
+      await tester.pumpWidget(_app(db: db, router: _router(id!, [])));
+      await _settle(tester);
+
+      await tester.tap(find.text(TamilStrings.helpful));
+      await _settle(tester);
+
+      final saved = await tester.runAsync(() => db.queryHistoryDao.getById(id));
+      expect(saved!.userRating, equals('thumbs_up'));
+    });
+
+    testWidgets('tapping the same rating again clears it to null',
+        (tester) async {
+      final id = await tester.runAsync(
+        () => _seedQuery(db, userRating: 'thumbs_up'),
+      );
+      await tester.pumpWidget(_app(db: db, router: _router(id!, [])));
+      await _settle(tester);
+
+      await tester.tap(find.text(TamilStrings.helpful));
+      await _settle(tester);
+
+      final saved = await tester.runAsync(() => db.queryHistoryDao.getById(id));
+      expect(saved!.userRating, isNull);
+    });
+
+    testWidgets('home button navigates to /', (tester) async {
+      final visited = <String>[];
+      final id = await tester.runAsync(() => _seedQuery(db));
+      await tester.pumpWidget(_app(db: db, router: _router(id!, visited)));
+      await _settle(tester);
+
+      await tester.tap(find.text(TamilStrings.goHome));
+      await _settle(tester);
+
+      expect(visited, contains('/'));
+    });
+
+    testWidgets('shows not-found message for unknown query id', (tester) async {
+      await tester.pumpWidget(_app(db: db, router: _router('does-not-exist', [])));
+      await _settle(tester);
+
+      expect(find.text(TamilStrings.queryNotFound), findsOneWidget);
+    });
+  });
+}

--- a/test/screens/settings/settings_screen_test.dart
+++ b/test/screens/settings/settings_screen_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nilam_ai/core/constants/strings_tamil.dart';
+import 'package:nilam_ai/providers/database_providers.dart';
+import 'package:nilam_ai/providers/settings_providers.dart';
+import 'package:nilam_ai/screens/settings/settings_screen.dart';
+import 'package:nilam_ai/services/database/database_service.dart';
+import 'package:nilam_ai/services/database/models/query_history.dart';
+import 'package:nilam_ai/services/database/models/user_profile.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:uuid/uuid.dart';
+
+GoRouter _router() => GoRouter(
+      initialLocation: '/settings',
+      routes: [
+        GoRoute(path: '/settings', builder: (_, _) => const SettingsScreen()),
+      ],
+    );
+
+Widget _app({
+  required DatabaseService db,
+  required SharedPreferences prefs,
+}) {
+  return ProviderScope(
+    overrides: [
+      databaseServiceProvider.overrideWithValue(db),
+      sharedPreferencesProvider.overrideWithValue(prefs),
+    ],
+    child: MaterialApp.router(routerConfig: _router()),
+  );
+}
+
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 6; i++) {
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+    });
+    await tester.pump();
+  }
+}
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late DatabaseService db;
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    db = DatabaseService.create();
+    await db.initialize(path: inMemoryDatabasePath);
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('SettingsScreen', () {
+    testWidgets('renders sections with default values', (tester) async {
+      await tester.pumpWidget(_app(db: db, prefs: prefs));
+      await _settle(tester);
+
+      expect(find.text(TamilStrings.ttsSpeedLabel), findsOneWidget);
+      expect(find.text(TamilStrings.notificationsLabel), findsOneWidget);
+      expect(find.text(TamilStrings.clearHistoryLabel), findsOneWidget);
+      expect(find.text(TamilStrings.aboutLabel), findsOneWidget);
+      expect(find.text('1.0x'), findsOneWidget);
+    });
+
+    testWidgets('toggling notifications switch persists value',
+        (tester) async {
+      await tester.pumpWidget(_app(db: db, prefs: prefs));
+      await _settle(tester);
+
+      await tester.tap(find.byType(SwitchListTile));
+      await _settle(tester);
+
+      expect(prefs.getBool('notifications_enabled'), isFalse);
+    });
+
+    testWidgets('clear-history confirm calls deleteAllForUser',
+        (tester) async {
+      // Seed a user and one query.
+      await tester.runAsync(() async {
+        final userId = const Uuid().v4();
+        final now = DateTime.now();
+        await db.userProfileDao.insert(UserProfile(
+          id: userId,
+          phoneNumber: 'local_user_default',
+          createdAt: now,
+          updatedAt: now,
+        ));
+        await db.queryHistoryDao.insert(QueryHistory(
+          id: const Uuid().v4(),
+          userId: userId,
+          timestamp: now,
+          transcription: 'test',
+          transcriptionConfidence: 1.0,
+          createdAt: now,
+          updatedAt: now,
+        ));
+      });
+
+      await tester.pumpWidget(_app(db: db, prefs: prefs));
+      await _settle(tester);
+
+      await tester.tap(find.text(TamilStrings.clearHistoryLabel));
+      await _settle(tester);
+      await tester.tap(find.text(TamilStrings.delete));
+      await _settle(tester);
+
+      final user =
+          await tester.runAsync(() => db.userProfileDao.getCurrent());
+      final remaining = await tester
+          .runAsync(() => db.queryHistoryDao.countForUser(user!.id));
+      expect(remaining, equals(0));
+    });
+  });
+}

--- a/test/screens/transcription/transcription_review_screen_test.dart
+++ b/test/screens/transcription/transcription_review_screen_test.dart
@@ -46,6 +46,13 @@ GoRouter _router({
           return const Scaffold(body: Text('RECORD_SCREEN'));
         },
       ),
+      GoRoute(
+        path: '/response/:queryId',
+        builder: (context, state) {
+          visited.add('/response');
+          return const Scaffold(body: Text('RESPONSE_SCREEN'));
+        },
+      ),
     ],
   );
 }


### PR DESCRIPTION
## Summary
- Wires the five MVP screens behind go_router with full Tamil localization, Material 3, and ≥48 dp touch targets. Replaces the placeholder home with a CTA that flows record → transcribe → review → response → home.
- New screens: [Home](lib/screens/home/home_screen.dart), [Response](lib/screens/response/response_screen.dart), [History](lib/screens/history/history_screen.dart), [Settings](lib/screens/settings/settings_screen.dart). Foundations: [`currentUserIdProvider`](lib/providers/user_providers.dart), [`settingsProvider`](lib/providers/settings_providers.dart), [`formatRelativeTamil`](lib/core/utils/relative_time.dart), and three new DAO-backed `FutureProvider.family` providers.
- 187/187 tests green, `flutter analyze` clean, app installs and runs on Moto g34 5G (Android 15).

## Stub points (intentional, tracked)
- [#15](https://github.com/learnzdevelopmenthub/nilamAI/issues/15) — Wire Gemma response into Response screen (parent: Phase 6 [#6](https://github.com/learnzdevelopmenthub/nilamAI/issues/6))
- [#16](https://github.com/learnzdevelopmenthub/nilamAI/issues/16) — Wire TTS audio playback into Response screen (parent: Phase 7 [#7](https://github.com/learnzdevelopmenthub/nilamAI/issues/7))
- [#17](https://github.com/learnzdevelopmenthub/nilamAI/issues/17) — End-to-end `integration_test/app_flow_test.dart` (parent: Phase 8 [#10](https://github.com/learnzdevelopmenthub/nilamAI/issues/10))
- [#18](https://github.com/learnzdevelopmenthub/nilamAI/issues/18) — Manual on-device verification: TalkBack, text scaling, cold-start (parent: Phase 8 [#10](https://github.com/learnzdevelopmenthub/nilamAI/issues/10))

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 187/187 pass
- [x] App installs and launches on Moto g34 5G (Android 15)
- [ ] Tap CTA → Record → Stop → Review → Confirm → Response shows transcription + placeholder
- [ ] Long-press a History tile → confirm dialog → tile disappears
- [ ] Settings: toggle notifications, drag TTS slider, force-stop, reopen → values retained
- [ ] Settings → Clear history → both Home recent list and History screen go empty

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)