### PR TITLE
Phase 6: On-device Gemma 4 E2B INT4 LLM service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,11 @@ docs/srs.md
 # Whisper model files (fetched via scripts/fetch_model.ps1 or .sh, too large for git)
 assets/models/*.bin
 
+# Gemma LLM model files (fetched via scripts/fetch_gemma_model.ps1 or .sh, too large for git)
+assets/models/*.litertlm
+
 # Flutter crash reports
 flutter_*.log
+
+# Test coverage reports
+coverage/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
-# nilam_ai
+# NilamAI (நிலம்AI)
 
-A new Flutter project.
+Offline-first Tamil agricultural advisory app for smallholder farmers in Tamil Nadu.
+See [docs/srs_1.0.md](docs/srs_1.0.md) for the canonical spec.
+
+## Prerequisites
+
+- Flutter 3.24+ / Dart SDK ^3.10.4
+- `curl` or `wget` (for fetch scripts on macOS/Linux), PowerShell on Windows
+- ~3 GB of free disk space for bundled models
+
+## First-time setup
+
+The app ships two on-device models that are **not** committed to git:
+
+- `ggml-base-q8_0.bin` (~75 MB) — Whisper Tamil STT (Phase 4)
+- `gemma_4_e2b_int4.litertlm` (~1.3 GB) — Gemma 4 E2B INT4 LLM (Phase 6)
+
+Fetch both once after cloning, before running `flutter run`:
+
+```bash
+# macOS / Linux
+bash scripts/fetch_model.sh
+bash scripts/fetch_gemma_model.sh
+
+# Windows (PowerShell)
+pwsh scripts/fetch_model.ps1
+pwsh scripts/fetch_gemma_model.ps1
+```
+
+Then:
+
+```bash
+flutter pub get
+flutter run
+```
+
+## Testing
+
+```bash
+flutter analyze
+flutter test
+flutter test --coverage
+```

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# Kotlin incremental compilation crashes with "different roots" when the Pub cache
+# is on C:\ and the project is on D:\ (Windows cross-drive layout). Disabling it
+# adds a few seconds per build but is required for cross-drive setups.
+kotlin.incremental=false

--- a/lib/core/exceptions/app_exception.dart
+++ b/lib/core/exceptions/app_exception.dart
@@ -3,12 +3,16 @@
 /// Error codes follow the SRS convention:
 /// - E001: Microphone errors
 /// - E002: STT errors (generic)
-/// - E003: LLM errors
+/// - E003: LLM errors (generic)
 /// - E004: TTS errors
 /// - E005: Database errors
 /// - E006: Whisper model not loaded
 /// - E007: Transcription failed
 /// - E008: Low confidence transcription
+/// - E009: Gemma model not loaded
+/// - E010: Gemma inference timeout (>30s)
+/// - E011: Gemma out of memory during inference
+/// - E012: Invalid query for Gemma
 sealed class AppException implements Exception {
   const AppException({
     required this.code,
@@ -63,7 +67,35 @@ class LlmException extends AppException {
   const LlmException({
     required super.message,
     super.originalError,
-  }) : super(code: 'E003');
+    super.code = 'E003',
+  });
+
+  LlmException.modelNotLoaded({Object? originalError})
+      : this(
+          code: 'E009',
+          message: 'Gemma model not loaded',
+          originalError: originalError,
+        );
+
+  LlmException.inferenceTimeout({Object? originalError})
+      : this(
+          code: 'E010',
+          message: 'Gemma inference timed out after 30s',
+          originalError: originalError,
+        );
+
+  LlmException.outOfMemory({Object? originalError})
+      : this(
+          code: 'E011',
+          message: 'Gemma inference ran out of memory',
+          originalError: originalError,
+        );
+
+  LlmException.invalidQuery(String detail)
+      : this(
+          code: 'E012',
+          message: 'Invalid query for Gemma: $detail',
+        );
 }
 
 class TtsException extends AppException {

--- a/lib/providers/llm_providers.dart
+++ b/lib/providers/llm_providers.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/exceptions/app_exception.dart';
+import '../core/logging/logger.dart';
+import '../services/llm/gemma_generator.dart';
+import '../services/llm/gemma_model_loader.dart';
+import '../services/llm/gemma_service.dart';
+
+// -----------------------------------------------------------------------------
+// Sealed Gemma state
+// -----------------------------------------------------------------------------
+
+sealed class GemmaState {
+  const GemmaState();
+}
+
+class GemmaIdle extends GemmaState {
+  const GemmaIdle();
+}
+
+class GemmaLoadingModel extends GemmaState {
+  const GemmaLoadingModel();
+}
+
+class GemmaGenerating extends GemmaState {
+  const GemmaGenerating();
+}
+
+class GemmaComplete extends GemmaState {
+  const GemmaComplete({required this.response});
+
+  final GemmaResponse response;
+}
+
+class GemmaError extends GemmaState {
+  const GemmaError({required this.code, required this.message});
+
+  final String code;
+  final String message;
+}
+
+// -----------------------------------------------------------------------------
+// Providers
+// -----------------------------------------------------------------------------
+
+final gemmaModelLoaderProvider = Provider<GemmaModelLoader>((ref) {
+  return GemmaModelLoader();
+});
+
+/// Production generator. Override with [OllamaGenerator] for dev, or with a
+/// fake for tests.
+final gemmaGeneratorProvider = Provider<GemmaGenerator>((ref) {
+  return FlutterGemmaGenerator();
+});
+
+final gemmaServiceProvider = Provider<GemmaService>((ref) {
+  return GemmaService(
+    loader: ref.watch(gemmaModelLoaderProvider),
+    generator: ref.watch(gemmaGeneratorProvider),
+  );
+});
+
+final gemmaNotifierProvider =
+    NotifierProvider<GemmaNotifier, GemmaState>(GemmaNotifier.new);
+
+// -----------------------------------------------------------------------------
+// Notifier
+// -----------------------------------------------------------------------------
+
+class GemmaNotifier extends Notifier<GemmaState> {
+  static const _tag = 'GemmaNotifier';
+
+  @override
+  GemmaState build() => const GemmaIdle();
+
+  GemmaService get _service => ref.read(gemmaServiceProvider);
+
+  /// Kicks off a full inference: LoadingModel → Generating → Complete/Error.
+  Future<void> generate({required String query, String? cropType}) async {
+    state = const GemmaLoadingModel();
+    AppLogger.info('Gemma generation started', _tag);
+
+    // Give the UI a frame to render "loading model" before heavy work.
+    await Future<void>.delayed(Duration.zero);
+
+    state = const GemmaGenerating();
+    try {
+      final response = await _service.generate(
+        query: query,
+        cropType: cropType,
+      );
+      state = GemmaComplete(response: response);
+      AppLogger.info(
+        'Gemma generation complete (${response.latencyMs} ms)',
+        _tag,
+      );
+    } on LlmException catch (e, st) {
+      AppLogger.error('Gemma failed (${e.code})', _tag, e, st);
+      state = GemmaError(code: e.code, message: e.message);
+    } catch (e, st) {
+      AppLogger.error('Gemma unexpected failure', _tag, e, st);
+      state = GemmaError(code: 'E003', message: e.toString());
+    }
+  }
+
+  void reset() {
+    state = const GemmaIdle();
+  }
+}

--- a/lib/services/llm/gemma_generator.dart
+++ b/lib/services/llm/gemma_generator.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:http/http.dart' as http;
+
+import '../../core/exceptions/app_exception.dart';
+import '../../core/logging/logger.dart';
+import 'llm_constants.dart';
+
+/// Minimal abstraction over the LLM backend so tests can substitute a fake
+/// without pulling in the native plugin or hitting a real Ollama server.
+///
+/// The `modelPath` parameter is used by the on-device `FlutterGemmaGenerator`
+/// to locate the `.litertlm` file; the `OllamaGenerator` dev bridge ignores
+/// it and uses its configured model name instead.
+abstract class GemmaGenerator {
+  Future<String> generate({
+    required String modelPath,
+    required String prompt,
+    required int maxTokens,
+    required double temperature,
+  });
+}
+
+/// Dev/demo generator that talks to a locally-running Ollama server over
+/// HTTP. Enables iteration on prompts and post-processing without needing
+/// the full LiteRT-LM native stack.
+///
+/// SRS references this bridge for the Ollama Prize integration. It is NOT
+/// the production path — `FlutterGemmaGenerator` is.
+class OllamaGenerator implements GemmaGenerator {
+  OllamaGenerator({
+    String? baseUrl,
+    String? modelName,
+    http.Client? client,
+  })  : baseUrl = baseUrl ?? LlmConstants.ollamaDefaultUrl,
+        modelName = modelName ?? LlmConstants.ollamaDefaultModel,
+        _client = client ?? http.Client();
+
+  final String baseUrl;
+  final String modelName;
+  final http.Client _client;
+
+  @override
+  Future<String> generate({
+    required String modelPath,
+    required String prompt,
+    required int maxTokens,
+    required double temperature,
+  }) async {
+    final uri = Uri.parse('$baseUrl/api/generate');
+    final body = jsonEncode({
+      'model': modelName,
+      'prompt': prompt,
+      'stream': false,
+      'options': {
+        'num_predict': maxTokens,
+        'temperature': temperature,
+      },
+    });
+
+    final response = await _client.post(
+      uri,
+      headers: const {'Content-Type': 'application/json'},
+      body: body,
+    );
+
+    if (response.statusCode != 200) {
+      throw LlmException(
+        message:
+            'Ollama returned HTTP ${response.statusCode}: ${response.body}',
+      );
+    }
+
+    // Decode as UTF-8 directly — Ollama doesn't always set charset=utf-8 and
+    // `response.body` defaults to Latin-1 in that case, which mangles Tamil.
+    final Map<String, dynamic> decoded =
+        jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+    final text = decoded['response'];
+    if (text is! String || text.isEmpty) {
+      throw const LlmException(
+        message: 'Ollama response missing "response" field',
+      );
+    }
+    return text;
+  }
+
+  /// Test-only — closes the underlying HTTP client.
+  void close() => _client.close();
+}
+
+/// Production on-device generator wrapping the `flutter_gemma` plugin
+/// (LiteRT-LM backend). Lazily installs the model on first call and
+/// reuses the loaded [InferenceModel] across subsequent invocations;
+/// a fresh [InferenceModelSession] is created per request so each call
+/// is one-shot with no conversation history.
+///
+/// Not covered by unit tests — trivial delegation to the plugin, which
+/// requires a real device for end-to-end validation (see Phase 8).
+class FlutterGemmaGenerator implements GemmaGenerator {
+  FlutterGemmaGenerator();
+
+  static const _tag = 'FlutterGemmaGenerator';
+
+  InferenceModel? _model;
+  String? _installedPath;
+  int? _installedMaxTokens;
+
+  @override
+  Future<String> generate({
+    required String modelPath,
+    required String prompt,
+    required int maxTokens,
+    required double temperature,
+  }) async {
+    try {
+      if (_model == null ||
+          _installedPath != modelPath ||
+          _installedMaxTokens != maxTokens) {
+        AppLogger.info('Installing Gemma model from $modelPath', _tag);
+        await FlutterGemma.installModel(
+          modelType: ModelType.gemmaIt,
+        ).fromFile(modelPath).install();
+
+        _model = await FlutterGemma.getActiveModel(maxTokens: maxTokens);
+        _installedPath = modelPath;
+        _installedMaxTokens = maxTokens;
+        AppLogger.info('Gemma model ready', _tag);
+      }
+
+      final session = await _model!.createSession(
+        temperature: temperature,
+      );
+
+      try {
+        await session.addQueryChunk(
+          Message.text(text: prompt, isUser: true),
+        );
+        return await session.getResponse();
+      } finally {
+        await session.close();
+      }
+    } on LlmException {
+      rethrow;
+    } catch (e, s) {
+      AppLogger.error('Gemma inference failed', _tag, e, s);
+      rethrow;
+    }
+  }
+
+  /// Releases the underlying model. Call on app shutdown or when switching
+  /// to a different generator (e.g. from production to Ollama dev bridge).
+  Future<void> close() async {
+    await _model?.close();
+    _model = null;
+    _installedPath = null;
+    _installedMaxTokens = null;
+  }
+}

--- a/lib/services/llm/gemma_model_loader.dart
+++ b/lib/services/llm/gemma_model_loader.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../../core/exceptions/app_exception.dart';
+import '../../core/logging/logger.dart';
+import 'llm_constants.dart';
+
+/// Returns the directory into which the model is copied.
+typedef AppDirProvider = Future<Directory> Function();
+
+/// Copies the bundled Gemma 4 E2B INT4 model (`.litertlm`, ~1.3 GB) from
+/// Flutter assets to a real filesystem path on first launch, so the native
+/// LiteRT-LM runtime can `mmap` it.
+///
+/// Subsequent launches detect the file and skip the copy.
+class GemmaModelLoader {
+  GemmaModelLoader({AssetBundle? assetBundle, AppDirProvider? appDirProvider})
+      : _assetBundle = assetBundle ?? rootBundle,
+        _appDirProvider = appDirProvider ?? getApplicationDocumentsDirectory;
+
+  static const _tag = 'GemmaModelLoader';
+
+  final AssetBundle _assetBundle;
+  final AppDirProvider _appDirProvider;
+  String? _cachedPath;
+
+  /// Ensures the model file is present on the local filesystem and returns
+  /// its absolute path. Throws [LlmException.modelNotLoaded] (E009) on I/O
+  /// error or missing asset.
+  Future<String> ensureModelAvailable() async {
+    if (_cachedPath != null) return _cachedPath!;
+
+    try {
+      final appDir = await _appDirProvider();
+      final modelDir = Directory('${appDir.path}/${LlmConstants.modelsSubDir}');
+      final target = File('${modelDir.path}/${LlmConstants.modelFileName}');
+
+      if (await target.exists() && await target.length() > 0) {
+        AppLogger.debug('Model already present at ${target.path}', _tag);
+        _cachedPath = target.path;
+        return target.path;
+      }
+
+      if (!await modelDir.exists()) {
+        await modelDir.create(recursive: true);
+      }
+
+      AppLogger.info('Copying bundled Gemma model to ${target.path}', _tag);
+      final bytes = await _assetBundle.load(LlmConstants.modelAssetPath);
+      await target.writeAsBytes(
+        bytes.buffer.asUint8List(bytes.offsetInBytes, bytes.lengthInBytes),
+        flush: true,
+      );
+      AppLogger.info(
+        'Model copy complete (${await target.length()} bytes)',
+        _tag,
+      );
+      _cachedPath = target.path;
+      return target.path;
+    } on LlmException {
+      rethrow;
+    } catch (e, s) {
+      AppLogger.error('Failed to load Gemma model', _tag, e, s);
+      throw LlmException.modelNotLoaded(originalError: e);
+    }
+  }
+
+  /// Test-only helper to reset the in-memory cache.
+  void resetCache() => _cachedPath = null;
+}

--- a/lib/services/llm/gemma_service.dart
+++ b/lib/services/llm/gemma_service.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+import '../../core/exceptions/app_exception.dart';
+import '../../core/logging/logger.dart';
+import 'gemma_generator.dart';
+import 'gemma_model_loader.dart';
+import 'llm_constants.dart';
+import 'prompt_builder.dart';
+import 'response_post_processor.dart';
+
+/// Outcome of a successful Gemma inference.
+///
+/// [text] is the post-processed Tamil response ready for TTS and UI.
+/// [rawText] is the untouched model output (kept for diagnostics).
+/// [prompt] is the assembled prompt — persist to `QueryHistory.gemmaPrompt`.
+/// [latencyMs] is wall-clock inference time — persist to
+/// `QueryHistory.gemmaLatencyMs`.
+class GemmaResponse {
+  const GemmaResponse({
+    required this.text,
+    required this.rawText,
+    required this.prompt,
+    required this.latencyMs,
+  });
+
+  final String text;
+  final String rawText;
+  final String prompt;
+  final int latencyMs;
+}
+
+/// High-level service that turns a Tamil query + optional crop context into
+/// a post-processed Tamil response using Gemma 4 E2B on-device.
+///
+/// Deliberately DB-free: the caller is responsible for persisting the
+/// [GemmaResponse] fields to `QueryHistory` and invalidating the Riverpod
+/// provider. Keeps this service unit-testable without sqflite.
+class GemmaService {
+  GemmaService({
+    required GemmaModelLoader loader,
+    required GemmaGenerator generator,
+  })  : _loader = loader,
+        _generator = generator;
+
+  static const _tag = 'GemmaService';
+
+  final GemmaModelLoader _loader;
+  final GemmaGenerator _generator;
+
+  /// Generates a Tamil response for [query], optionally contextualized with
+  /// [cropType] from the user profile.
+  ///
+  /// Error handling (SRS §10.3):
+  /// - [LlmException.invalidQuery] (E012) — empty/whitespace query
+  /// - [LlmException.modelNotLoaded] (E009) — model asset missing or I/O error
+  /// - [LlmException.inferenceTimeout] (E010) — >30 s without a response
+  /// - [LlmException.outOfMemory] (E011) — OOM during inference
+  Future<GemmaResponse> generate({
+    required String query,
+    String? cropType,
+  }) async {
+    // PromptBuilder throws E012 on empty/whitespace.
+    final built = PromptBuilder.build(query: query, cropType: cropType);
+
+    final String modelPath;
+    try {
+      modelPath = await _loader.ensureModelAvailable();
+    } on LlmException {
+      rethrow;
+    } catch (e) {
+      throw LlmException.modelNotLoaded(originalError: e);
+    }
+
+    final stopwatch = Stopwatch()..start();
+    try {
+      final raw = await _generator
+          .generate(
+            modelPath: modelPath,
+            prompt: built.text,
+            maxTokens: LlmConstants.maxOutputTokens,
+            temperature: LlmConstants.temperature,
+          )
+          .timeout(
+            const Duration(seconds: LlmConstants.inferenceTimeoutSeconds),
+          );
+      stopwatch.stop();
+      AppLogger.info(
+        'Gemma inference complete in ${stopwatch.elapsedMilliseconds} ms',
+        _tag,
+      );
+
+      return GemmaResponse(
+        text: ResponsePostProcessor.process(raw),
+        rawText: raw,
+        prompt: built.text,
+        latencyMs: stopwatch.elapsedMilliseconds,
+      );
+    } on TimeoutException catch (e) {
+      AppLogger.error('Gemma inference timed out', _tag, e);
+      throw LlmException.inferenceTimeout(originalError: e);
+    } on OutOfMemoryError catch (e, s) {
+      AppLogger.error('Gemma ran out of memory', _tag, e, s);
+      throw LlmException.outOfMemory(originalError: e);
+    } on LlmException {
+      rethrow;
+    } catch (e, s) {
+      AppLogger.error('Gemma inference failed', _tag, e, s);
+      throw LlmException(
+        message: 'Gemma inference failed: $e',
+        originalError: e,
+      );
+    }
+  }
+}

--- a/lib/services/llm/llm_constants.dart
+++ b/lib/services/llm/llm_constants.dart
@@ -1,0 +1,30 @@
+/// Gemma LLM configuration constants for NilamAI.
+///
+/// Uses Gemma 4 E2B INT4 quantized model (~1.3 GB, `.litertlm` format).
+/// Bundled in the APK via `assets/models/` and copied to app documents on
+/// first launch by [GemmaModelLoader].
+///
+/// Values follow `docs/srs_1.0.md` §8 (revised 2026-04-16) where they differ
+/// from GitHub issue #6.
+class LlmConstants {
+  LlmConstants._();
+
+  // -- Model --
+  static const String modelAssetPath =
+      'assets/models/gemma_4_e2b_int4.litertlm';
+  static const String modelFileName = 'gemma_4_e2b_int4.litertlm';
+  static const String modelsSubDir = 'models';
+
+  // -- Inference --
+  static const int maxOutputTokens = 300;
+  static const int maxContextTokens = 600;
+  static const double temperature = 0.3;
+  static const int inferenceTimeoutSeconds = 30;
+
+  // -- Ollama dev bridge --
+  static const String ollamaDefaultUrl = 'http://localhost:11434';
+  static const String ollamaDefaultModel = 'gemma2:2b';
+
+  // -- Language --
+  static const String language = 'ta';
+}

--- a/lib/services/llm/prompt_builder.dart
+++ b/lib/services/llm/prompt_builder.dart
@@ -1,0 +1,57 @@
+import 'llm_constants.dart';
+import '../../core/exceptions/app_exception.dart';
+
+/// Result of building a Gemma prompt: the final prompt string ready for
+/// inference, plus the raw query for later persistence in `QueryHistory`.
+class BuiltPrompt {
+  const BuiltPrompt({required this.text, required this.query});
+
+  /// The fully-assembled prompt sent to the LLM.
+  final String text;
+
+  /// The raw user query (unmodified), retained for DB persistence.
+  final String query;
+}
+
+/// Assembles the Tamil system prompt + user context for Gemma 4 E2B.
+///
+/// The SRS (§8) does not prescribe a specific Tamil prompt template — only
+/// the English "selling advice" example. This builder produces a generic
+/// agricultural-advisor prompt that works for disease, crop, and pricing
+/// queries; iterate post-merge as real responses surface.
+///
+/// Only `cropType` is injected as context in this phase. Geolocation,
+/// season, and mandi prices (SRS FR-4.2 "if available") are tracked as
+/// separate tickets.
+class PromptBuilder {
+  PromptBuilder._();
+
+  static const String _systemLine =
+      'நீ NilamAI (நிலம்AI) — தமிழ்நாட்டு விவசாயிகளுக்கான ஆலோசகர்.';
+  static const String _instructionLine =
+      'தமிழில் சுருக்கமாக பதில் சொல். செயல்முறை படிகள், செலவு, மற்றும் நேரம் ஆகியவற்றைச் சேர்.';
+
+  /// Builds a Tamil prompt for Gemma.
+  ///
+  /// Throws [LlmException.invalidQuery] (E012) when [query] is empty
+  /// after trimming.
+  static BuiltPrompt build({required String query, String? cropType}) {
+    final trimmedQuery = query.trim();
+    if (trimmedQuery.isEmpty) {
+      throw LlmException.invalidQuery('query is empty');
+    }
+
+    final trimmedCrop = cropType?.trim();
+    final cropLine =
+        (trimmedCrop != null && trimmedCrop.isNotEmpty) ? 'பயிர்: $trimmedCrop\n' : '';
+
+    final prompt = '''$_systemLine
+
+கேள்வி: $trimmedQuery
+$cropLine
+$_instructionLine
+(மொழி: ${LlmConstants.language})''';
+
+    return BuiltPrompt(text: prompt, query: trimmedQuery);
+  }
+}

--- a/lib/services/llm/response_post_processor.dart
+++ b/lib/services/llm/response_post_processor.dart
@@ -1,0 +1,97 @@
+/// Cleans raw Gemma output into TTS-ready plain Tamil text.
+///
+/// Per `docs/srs_1.0.md` §7.8 the post-processor must:
+///   - Strip markdown (headers, bold, backticks, list bullets)
+///   - Expand common abbreviations so TTS pronounces them correctly
+///   - Preserve paragraph breaks (TTS uses them as pause cues)
+///
+/// Structured action-item extraction (steps / costs / timeline) is
+/// documented in SRS §7.8 as a longer-term goal and is **out of scope**
+/// for Phase 6; we preserve line breaks so visible structure survives.
+class ResponsePostProcessor {
+  ResponsePostProcessor._();
+
+  /// Tamil/English abbreviations Gemma commonly emits, mapped to their
+  /// spoken Tamil forms. Kept small and conservative — only high-confidence
+  /// expansions that improve TTS clarity.
+  static const Map<String, String> _abbreviations = {
+    'kg': 'கிலோ',
+    'Kg': 'கிலோ',
+    'KG': 'கிலோ',
+    'gm': 'கிராம்',
+    'gms': 'கிராம்',
+    'g': 'கிராம்',
+    'ha': 'ஹெக்டேர்',
+    'mm': 'மில்லிமீட்டர்',
+    'cm': 'சென்டிமீட்டர்',
+    'ml': 'மில்லிலிட்டர்',
+    'L': 'லிட்டர்',
+    'ltr': 'லிட்டர்',
+    'Rs': 'ரூபாய்',
+    'INR': 'ரூபாய்',
+    '₹': 'ரூபாய்',
+  };
+
+  /// Pipeline: strip markdown → expand abbreviations → collapse excess
+  /// whitespace. Idempotent on already-clean input.
+  static String process(String raw) {
+    var text = raw;
+    text = _stripMarkdown(text);
+    text = _expandAbbreviations(text);
+    text = _collapseWhitespace(text);
+    return text.trim();
+  }
+
+  static String _stripMarkdown(String input) {
+    var t = input;
+    // Triple-backtick fenced code blocks.
+    t = t.replaceAll(RegExp(r'```[\s\S]*?```'), '');
+    // Inline backticks.
+    t = t.replaceAll('`', '');
+    // Bold/italic markers (**text**, *text*, __text__, _text_).
+    // `replaceAll` with a String doesn't expand $1 backrefs in Dart —
+    // `replaceAllMapped` is required to keep the captured content.
+    String unwrap(RegExp pattern) => t = t.replaceAllMapped(
+          pattern,
+          (m) => m.group(1) ?? '',
+        );
+    unwrap(RegExp(r'\*\*(.*?)\*\*'));
+    unwrap(RegExp(r'__(.*?)__'));
+    unwrap(RegExp(r'(?<!\*)\*(?!\*)(.*?)(?<!\*)\*(?!\*)'));
+    unwrap(RegExp(r'(?<!_)_(?!_)(.*?)(?<!_)_(?!_)'));
+    // ATX headers: leading #+ on a line.
+    t = t.replaceAll(RegExp(r'^#{1,6}\s+', multiLine: true), '');
+    // Unordered list bullets: leading -, *, or + (followed by space).
+    t = t.replaceAll(RegExp(r'^\s*[-*+]\s+', multiLine: true), '');
+    // Ordered list markers: "1. ", "2. ", ...
+    t = t.replaceAll(RegExp(r'^\s*\d+\.\s+', multiLine: true), '');
+    // Blockquote markers.
+    t = t.replaceAll(RegExp(r'^\s*>+\s?', multiLine: true), '');
+    return t;
+  }
+
+  static String _expandAbbreviations(String input) {
+    var t = input;
+    for (final entry in _abbreviations.entries) {
+      // Currency symbol (single char) — no word boundary.
+      if (entry.key == '₹') {
+        t = t.replaceAll(entry.key, entry.value);
+        continue;
+      }
+      // Whole-word replacement (word boundaries on both sides).
+      final pattern = RegExp(r'\b' + RegExp.escape(entry.key) + r'\b');
+      t = t.replaceAll(pattern, entry.value);
+    }
+    return t;
+  }
+
+  static String _collapseWhitespace(String input) {
+    // Collapse 3+ consecutive newlines into a single blank line.
+    var t = input.replaceAll(RegExp(r'\n{3,}'), '\n\n');
+    // Strip trailing spaces on each line.
+    t = t.replaceAll(RegExp(r'[ \t]+\n'), '\n');
+    // Collapse runs of non-newline whitespace to single space.
+    t = t.replaceAll(RegExp(r'[ \t]{2,}'), ' ');
+    return t;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,8 @@ dependencies:
   path_provider: ^2.1.0
   whisper_ggml: ^1.7.0
   package_info_plus: ^8.0.0
+  http: ^1.2.0
+  flutter_gemma: ^0.12.6
 
 dev_dependencies:
   flutter_test:

--- a/scripts/fetch_gemma_model.ps1
+++ b/scripts/fetch_gemma_model.ps1
@@ -1,0 +1,34 @@
+#!/usr/bin/env pwsh
+# Fetches the Gemma 4 E2B INT4 model (.litertlm, ~1.3 GB) for NilamAI.
+# Run once after cloning: pwsh scripts/fetch_gemma_model.ps1
+# Required for Phase 6 on-device LLM inference.
+#
+# NOTE: The exact HuggingFace revision is not yet pinned in SRS §8. The
+# checkpoint below is the reference `litert-community/gemma-4-E2B-it-litert-lm`
+# repo; confirm availability and swap in the pinned revision before release.
+# See: docs/srs_1.0.md §8 (Model Strategy) and GitHub issue #6.
+
+$ErrorActionPreference = 'Stop'
+$modelUrl = 'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma_4_e2b_int4.litertlm'
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$targetDir = Join-Path $repoRoot 'assets\models'
+$targetFile = Join-Path $targetDir 'gemma_4_e2b_int4.litertlm'
+$minBytes = 1GB
+
+if (-not (Test-Path $targetDir)) {
+    New-Item -ItemType Directory -Path $targetDir | Out-Null
+}
+
+if ((Test-Path $targetFile) -and (Get-Item $targetFile).Length -gt $minBytes) {
+    $existingMb = '{0:N0}' -f ((Get-Item $targetFile).Length / 1MB)
+    Write-Host "Gemma model already present at $targetFile ($existingMb MB)"
+    exit 0
+}
+
+Write-Host "Downloading gemma_4_e2b_int4.litertlm (~1.3 GB) from Huggingface..."
+Write-Host "  URL: $modelUrl"
+Write-Host "  If this fails, the checkpoint may have moved — see docs/srs_1.0.md §8."
+Invoke-WebRequest -Uri $modelUrl -OutFile $targetFile
+$sizeMb = '{0:N0}' -f ((Get-Item $targetFile).Length / 1MB)
+Write-Host "Downloaded $sizeMb MB to $targetFile"

--- a/scripts/fetch_gemma_model.sh
+++ b/scripts/fetch_gemma_model.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Fetches the Gemma 4 E2B INT4 model (.litertlm, ~1.3 GB) for NilamAI.
+# Run once after cloning: bash scripts/fetch_gemma_model.sh
+# Required for Phase 6 on-device LLM inference.
+#
+# NOTE: The exact HuggingFace revision is not yet pinned in SRS §8. The
+# checkpoint below is the reference `litert-community/gemma-4-E2B-it-litert-lm`
+# repo; confirm availability and swap in the pinned revision before release.
+# See: docs/srs_1.0.md §8 (Model Strategy) and GitHub issue #6.
+
+set -euo pipefail
+
+MODEL_URL='https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma_4_e2b_int4.litertlm'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TARGET_DIR="$REPO_ROOT/assets/models"
+TARGET_FILE="$TARGET_DIR/gemma_4_e2b_int4.litertlm"
+MIN_BYTES=$((1024 * 1024 * 1024)) # 1 GB sanity threshold
+
+mkdir -p "$TARGET_DIR"
+
+if [ -f "$TARGET_FILE" ]; then
+    existing_size="$(stat -c%s "$TARGET_FILE" 2>/dev/null || stat -f%z "$TARGET_FILE")"
+    if [ "$existing_size" -gt "$MIN_BYTES" ]; then
+        echo "Gemma model already present at $TARGET_FILE ($((existing_size / 1024 / 1024)) MB)"
+        exit 0
+    fi
+fi
+
+echo "Downloading gemma_4_e2b_int4.litertlm (~1.3 GB) from Huggingface..."
+echo "  URL: $MODEL_URL"
+echo "  If this fails, the checkpoint may have moved — see docs/srs_1.0.md §8."
+if command -v curl >/dev/null; then
+    curl -L -o "$TARGET_FILE" "$MODEL_URL"
+elif command -v wget >/dev/null; then
+    wget -O "$TARGET_FILE" "$MODEL_URL"
+else
+    echo "Neither curl nor wget found — install one and retry." >&2
+    exit 1
+fi
+
+downloaded_size="$(stat -c%s "$TARGET_FILE" 2>/dev/null || stat -f%z "$TARGET_FILE")"
+echo "Downloaded $((downloaded_size / 1024 / 1024)) MB to $TARGET_FILE"

--- a/test/core/exceptions/llm_exception_test.dart
+++ b/test/core/exceptions/llm_exception_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+
+void main() {
+  group('LlmException factories', () {
+    test('default constructor uses E003', () {
+      const e = LlmException(message: 'generic failure');
+      expect(e.code, equals('E003'));
+    });
+
+    test('modelNotLoaded has code E009', () {
+      final e = LlmException.modelNotLoaded();
+      expect(e.code, equals('E009'));
+      expect(e.message, contains('model'));
+    });
+
+    test('modelNotLoaded preserves originalError', () {
+      final original = FormatException('io error');
+      final e = LlmException.modelNotLoaded(originalError: original);
+      expect(e.originalError, same(original));
+    });
+
+    test('inferenceTimeout has code E010', () {
+      final e = LlmException.inferenceTimeout();
+      expect(e.code, equals('E010'));
+      expect(e.message, contains('30'));
+    });
+
+    test('inferenceTimeout preserves originalError', () {
+      final original = StateError('timed out');
+      final e = LlmException.inferenceTimeout(originalError: original);
+      expect(e.originalError, same(original));
+    });
+
+    test('outOfMemory has code E011', () {
+      final e = LlmException.outOfMemory();
+      expect(e.code, equals('E011'));
+      expect(e.message, contains('memory'));
+    });
+
+    test('outOfMemory preserves originalError', () {
+      final original = OutOfMemoryError();
+      final e = LlmException.outOfMemory(originalError: original);
+      expect(e.originalError, same(original));
+    });
+
+    test('invalidQuery has code E012 with detail', () {
+      final e = LlmException.invalidQuery('empty transcription');
+      expect(e.code, equals('E012'));
+      expect(e.message, contains('empty transcription'));
+    });
+
+    test('toString includes the error code', () {
+      final e = LlmException.modelNotLoaded();
+      expect(e.toString(), contains('E009'));
+    });
+  });
+}

--- a/test/providers/llm_providers_test.dart
+++ b/test/providers/llm_providers_test.dart
@@ -1,0 +1,163 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+import 'package:nilam_ai/providers/llm_providers.dart';
+import 'package:nilam_ai/services/llm/gemma_generator.dart';
+import 'package:nilam_ai/services/llm/gemma_model_loader.dart';
+
+class _FakeGenerator implements GemmaGenerator {
+  _FakeGenerator({this.text = 'தமிழ் பதில்.'});
+
+  final String text;
+
+  @override
+  Future<String> generate({
+    required String modelPath,
+    required String prompt,
+    required int maxTokens,
+    required double temperature,
+  }) async {
+    return text;
+  }
+}
+
+class _FakeLoader extends GemmaModelLoader {
+  _FakeLoader({this.shouldThrow = false})
+      : super(assetBundle: _EmptyBundle(), appDirProvider: _tempDir);
+
+  final bool shouldThrow;
+
+  @override
+  Future<String> ensureModelAvailable() async {
+    if (shouldThrow) throw LlmException.modelNotLoaded();
+    return '/fake/gemma.litertlm';
+  }
+}
+
+class _EmptyBundle extends CachingAssetBundle {
+  @override
+  Future<ByteData> load(String key) async => ByteData(0);
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async => '';
+}
+
+Future<Directory> _tempDir() async => Directory.systemTemp;
+
+void main() {
+  group('GemmaNotifier state transitions', () {
+    late ProviderContainer container;
+
+    tearDown(() => container.dispose());
+
+    test('initial state is GemmaIdle', () {
+      container = ProviderContainer();
+      expect(container.read(gemmaNotifierProvider), isA<GemmaIdle>());
+    });
+
+    test('happy path: LoadingModel → Generating → Complete', () async {
+      container = ProviderContainer(
+        overrides: [
+          gemmaModelLoaderProvider.overrideWithValue(_FakeLoader()),
+          gemmaGeneratorProvider.overrideWithValue(
+            _FakeGenerator(text: 'சுத்தமான பதில்.'),
+          ),
+        ],
+      );
+
+      final states = <GemmaState>[];
+      container.listen<GemmaState>(
+        gemmaNotifierProvider,
+        (_, next) => states.add(next),
+        fireImmediately: true,
+      );
+
+      await container
+          .read(gemmaNotifierProvider.notifier)
+          .generate(query: 'q', cropType: 'நெல்');
+
+      expect(states.first, isA<GemmaIdle>());
+      expect(states.any((s) => s is GemmaLoadingModel), isTrue);
+      expect(states.any((s) => s is GemmaGenerating), isTrue);
+      expect(states.last, isA<GemmaComplete>());
+
+      final complete = states.last as GemmaComplete;
+      expect(complete.response.text, equals('சுத்தமான பதில்.'));
+      expect(complete.response.prompt, contains('கேள்வி: q'));
+      expect(complete.response.prompt, contains('பயிர்: நெல்'));
+    });
+
+    test('model-load failure surfaces GemmaError with E009', () async {
+      container = ProviderContainer(
+        overrides: [
+          gemmaModelLoaderProvider
+              .overrideWithValue(_FakeLoader(shouldThrow: true)),
+          gemmaGeneratorProvider.overrideWithValue(_FakeGenerator()),
+        ],
+      );
+
+      await container
+          .read(gemmaNotifierProvider.notifier)
+          .generate(query: 'q');
+
+      final state = container.read(gemmaNotifierProvider);
+      expect(state, isA<GemmaError>());
+      expect((state as GemmaError).code, equals('E009'));
+    });
+
+    test('empty query surfaces GemmaError with E012', () async {
+      container = ProviderContainer(
+        overrides: [
+          gemmaModelLoaderProvider.overrideWithValue(_FakeLoader()),
+          gemmaGeneratorProvider.overrideWithValue(_FakeGenerator()),
+        ],
+      );
+
+      await container
+          .read(gemmaNotifierProvider.notifier)
+          .generate(query: '');
+
+      final state = container.read(gemmaNotifierProvider);
+      expect(state, isA<GemmaError>());
+      expect((state as GemmaError).code, equals('E012'));
+    });
+
+    test('reset returns state to GemmaIdle', () async {
+      container = ProviderContainer(
+        overrides: [
+          gemmaModelLoaderProvider.overrideWithValue(_FakeLoader()),
+          gemmaGeneratorProvider.overrideWithValue(_FakeGenerator()),
+        ],
+      );
+
+      await container
+          .read(gemmaNotifierProvider.notifier)
+          .generate(query: 'q');
+      expect(container.read(gemmaNotifierProvider), isA<GemmaComplete>());
+
+      container.read(gemmaNotifierProvider.notifier).reset();
+      expect(container.read(gemmaNotifierProvider), isA<GemmaIdle>());
+    });
+
+    test('exhaustive sealed switch compiles for every state', () {
+      String label(GemmaState s) => switch (s) {
+            GemmaIdle() => 'idle',
+            GemmaLoadingModel() => 'loading',
+            GemmaGenerating() => 'generating',
+            GemmaComplete() => 'complete',
+            GemmaError() => 'error',
+          };
+
+      expect(label(const GemmaIdle()), 'idle');
+      expect(label(const GemmaLoadingModel()), 'loading');
+      expect(label(const GemmaGenerating()), 'generating');
+      expect(
+        label(const GemmaError(code: 'E003', message: 'm')),
+        'error',
+      );
+    });
+  });
+}

--- a/test/services/llm/gemma_model_loader_test.dart
+++ b/test/services/llm/gemma_model_loader_test.dart
@@ -1,0 +1,143 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+import 'package:nilam_ai/services/llm/gemma_model_loader.dart';
+import 'package:nilam_ai/services/llm/llm_constants.dart';
+
+/// Fake AssetBundle that returns pre-seeded bytes for a given asset path.
+class _FakeAssetBundle extends CachingAssetBundle {
+  _FakeAssetBundle(this._assets);
+
+  final Map<String, Uint8List> _assets;
+  int loadCalls = 0;
+
+  @override
+  Future<ByteData> load(String key) async {
+    loadCalls += 1;
+    final bytes = _assets[key];
+    if (bytes == null) {
+      throw FlutterError('Asset not found: $key');
+    }
+    return ByteData.sublistView(bytes);
+  }
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async {
+    throw UnimplementedError();
+  }
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('gemma_loader_test_');
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Future<Directory> fakeAppDir() async => tempDir;
+
+  group('GemmaModelLoader.ensureModelAvailable', () {
+    test('copies bundled asset on first call and returns file path', () async {
+      final payload = Uint8List.fromList(
+        List<int>.generate(4096, (i) => i % 256),
+      );
+      final bundle = _FakeAssetBundle({
+        LlmConstants.modelAssetPath: payload,
+      });
+      final loader = GemmaModelLoader(
+        assetBundle: bundle,
+        appDirProvider: fakeAppDir,
+      );
+
+      final path = await loader.ensureModelAvailable();
+
+      expect(path, endsWith(LlmConstants.modelFileName));
+      final file = File(path);
+      expect(await file.exists(), isTrue);
+      expect(await file.length(), equals(payload.length));
+      expect(bundle.loadCalls, equals(1));
+    });
+
+    test('skips copy on subsequent calls when model already cached', () async {
+      final payload = Uint8List.fromList(List<int>.filled(1024, 7));
+      final bundle = _FakeAssetBundle({
+        LlmConstants.modelAssetPath: payload,
+      });
+      final loader = GemmaModelLoader(
+        assetBundle: bundle,
+        appDirProvider: fakeAppDir,
+      );
+
+      final p1 = await loader.ensureModelAvailable();
+      final p2 = await loader.ensureModelAvailable();
+
+      expect(p1, equals(p2));
+      expect(bundle.loadCalls, equals(1));
+    });
+
+    test('skips copy when file already on disk (no cache) but not in memory',
+        () async {
+      final payload = Uint8List.fromList(List<int>.filled(1024, 3));
+      final bundle = _FakeAssetBundle({
+        LlmConstants.modelAssetPath: payload,
+      });
+      final loader = GemmaModelLoader(
+        assetBundle: bundle,
+        appDirProvider: fakeAppDir,
+      );
+
+      await loader.ensureModelAvailable();
+      loader.resetCache();
+      await loader.ensureModelAvailable();
+
+      expect(bundle.loadCalls, equals(1)); // second call used on-disk file
+    });
+
+    test('throws LlmException(E009) when asset is missing', () async {
+      final bundle = _FakeAssetBundle(const {});
+      final loader = GemmaModelLoader(
+        assetBundle: bundle,
+        appDirProvider: fakeAppDir,
+      );
+
+      await expectLater(
+        loader.ensureModelAvailable(),
+        throwsA(
+          isA<LlmException>().having((e) => e.code, 'code', 'E009'),
+        ),
+      );
+    });
+
+    test('creates the models subdirectory if missing', () async {
+      final payload = Uint8List.fromList(List<int>.filled(1024, 1));
+      final bundle = _FakeAssetBundle({
+        LlmConstants.modelAssetPath: payload,
+      });
+      final loader = GemmaModelLoader(
+        assetBundle: bundle,
+        appDirProvider: fakeAppDir,
+      );
+
+      expect(
+        await Directory('${tempDir.path}/${LlmConstants.modelsSubDir}').exists(),
+        isFalse,
+      );
+
+      await loader.ensureModelAvailable();
+
+      expect(
+        await Directory('${tempDir.path}/${LlmConstants.modelsSubDir}').exists(),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/services/llm/gemma_service_test.dart
+++ b/test/services/llm/gemma_service_test.dart
@@ -1,0 +1,216 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+import 'package:nilam_ai/services/llm/gemma_generator.dart';
+import 'package:nilam_ai/services/llm/gemma_model_loader.dart';
+import 'package:nilam_ai/services/llm/gemma_service.dart';
+import 'package:nilam_ai/services/llm/llm_constants.dart';
+
+class _FakeGenerator implements GemmaGenerator {
+  _FakeGenerator({
+    this.text = 'தமிழ் பதில்.',
+    this.error,
+    this.delay = Duration.zero,
+  });
+
+  final String text;
+  final Object? error;
+  final Duration delay;
+
+  String? lastPrompt;
+  int? lastMaxTokens;
+  double? lastTemperature;
+  String? lastModelPath;
+  int callCount = 0;
+
+  @override
+  Future<String> generate({
+    required String modelPath,
+    required String prompt,
+    required int maxTokens,
+    required double temperature,
+  }) async {
+    callCount += 1;
+    lastModelPath = modelPath;
+    lastPrompt = prompt;
+    lastMaxTokens = maxTokens;
+    lastTemperature = temperature;
+    if (delay != Duration.zero) {
+      await Future<void>.delayed(delay);
+    }
+    if (error != null) {
+      throw error!;
+    }
+    return text;
+  }
+}
+
+class _FakeLoader extends GemmaModelLoader {
+  _FakeLoader({this.path = '/fake/model.litertlm', this.error})
+      : super(assetBundle: _EmptyBundle(), appDirProvider: _noop);
+
+  final String path;
+  final Object? error;
+  int calls = 0;
+
+  @override
+  Future<String> ensureModelAvailable() async {
+    calls += 1;
+    if (error != null) {
+      throw error!;
+    }
+    return path;
+  }
+}
+
+class _EmptyBundle extends CachingAssetBundle {
+  @override
+  Future<ByteData> load(String key) async => ByteData(0);
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async => '';
+}
+
+Future<Directory> _noop() async => Directory.systemTemp;
+
+void main() {
+  group('GemmaService.generate — happy path', () {
+    test('returns post-processed text, raw text, prompt, and latency', () async {
+      final gen = _FakeGenerator(text: '**5 kg** விதை போடு.');
+      final svc = GemmaService(loader: _FakeLoader(), generator: gen);
+
+      final result = await svc.generate(query: 'query', cropType: 'நெல்');
+
+      expect(result.rawText, equals('**5 kg** விதை போடு.'));
+      // Post-processor strips bold and expands kg.
+      expect(result.text, equals('5 கிலோ விதை போடு.'));
+      expect(result.prompt, contains('கேள்வி: query'));
+      expect(result.prompt, contains('பயிர்: நெல்'));
+      expect(result.latencyMs, greaterThanOrEqualTo(0));
+    });
+
+    test('uses LlmConstants for maxTokens and temperature', () async {
+      final gen = _FakeGenerator();
+      final svc = GemmaService(loader: _FakeLoader(), generator: gen);
+
+      await svc.generate(query: 'q');
+
+      expect(gen.lastMaxTokens, equals(LlmConstants.maxOutputTokens));
+      expect(gen.lastTemperature, equals(LlmConstants.temperature));
+    });
+
+    test('passes the resolved model path from the loader to the generator',
+        () async {
+      final gen = _FakeGenerator();
+      final loader = _FakeLoader(path: '/tmp/gemma.litertlm');
+      final svc = GemmaService(loader: loader, generator: gen);
+
+      await svc.generate(query: 'q');
+
+      expect(gen.lastModelPath, equals('/tmp/gemma.litertlm'));
+      expect(loader.calls, equals(1));
+    });
+
+    test('omits crop context from prompt when cropType is null', () async {
+      final gen = _FakeGenerator();
+      final svc = GemmaService(loader: _FakeLoader(), generator: gen);
+
+      await svc.generate(query: 'q');
+
+      expect(gen.lastPrompt!.contains('பயிர்:'), isFalse);
+    });
+  });
+
+  group('GemmaService.generate — error mapping', () {
+    test('empty query throws LlmException(E012)', () async {
+      final svc = GemmaService(
+        loader: _FakeLoader(),
+        generator: _FakeGenerator(),
+      );
+
+      await expectLater(
+        svc.generate(query: ''),
+        throwsA(
+          isA<LlmException>().having((e) => e.code, 'code', 'E012'),
+        ),
+      );
+    });
+
+    test('model-not-loaded bubbles up as E009', () async {
+      final svc = GemmaService(
+        loader: _FakeLoader(error: LlmException.modelNotLoaded()),
+        generator: _FakeGenerator(),
+      );
+
+      await expectLater(
+        svc.generate(query: 'q'),
+        throwsA(
+          isA<LlmException>().having((e) => e.code, 'code', 'E009'),
+        ),
+      );
+    });
+
+    test('non-LlmException loader error is wrapped as E009', () async {
+      final svc = GemmaService(
+        loader: _FakeLoader(error: StateError('disk full')),
+        generator: _FakeGenerator(),
+      );
+
+      await expectLater(
+        svc.generate(query: 'q'),
+        throwsA(
+          isA<LlmException>().having((e) => e.code, 'code', 'E009'),
+        ),
+      );
+    });
+
+    test('generator timeout throws LlmException(E010)', () async {
+      // Delay longer than the configured inference timeout.
+      final longDelay = Duration(
+        seconds: LlmConstants.inferenceTimeoutSeconds + 5,
+      );
+      final svc = GemmaService(
+        loader: _FakeLoader(),
+        generator: _FakeGenerator(delay: longDelay),
+      );
+
+      await expectLater(
+        svc.generate(query: 'q'),
+        throwsA(
+          isA<LlmException>().having((e) => e.code, 'code', 'E010'),
+        ),
+      );
+    }, timeout: Timeout(Duration(seconds: 60)));
+
+    test('generator OutOfMemoryError throws LlmException(E011)', () async {
+      final svc = GemmaService(
+        loader: _FakeLoader(),
+        generator: _FakeGenerator(error: OutOfMemoryError()),
+      );
+
+      await expectLater(
+        svc.generate(query: 'q'),
+        throwsA(
+          isA<LlmException>().having((e) => e.code, 'code', 'E011'),
+        ),
+      );
+    });
+
+    test('unknown generator exception wraps as generic LlmException(E003)',
+        () async {
+      final svc = GemmaService(
+        loader: _FakeLoader(),
+        generator: _FakeGenerator(error: FormatException('boom')),
+      );
+
+      await expectLater(
+        svc.generate(query: 'q'),
+        throwsA(
+          isA<LlmException>().having((e) => e.code, 'code', 'E003'),
+        ),
+      );
+    });
+  });
+}

--- a/test/services/llm/ollama_generator_test.dart
+++ b/test/services/llm/ollama_generator_test.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+import 'package:nilam_ai/services/llm/gemma_generator.dart';
+
+void main() {
+  group('OllamaGenerator.generate', () {
+    test('POSTs prompt and returns the response field', () async {
+      http.Request? captured;
+      final client = MockClient((request) async {
+        captured = request;
+        return http.Response.bytes(
+          utf8.encode(jsonEncode({'response': 'தமிழ் பதில்.', 'done': true})),
+          200,
+          headers: const {'content-type': 'application/json; charset=utf-8'},
+        );
+      });
+
+      final gen = OllamaGenerator(
+        baseUrl: 'http://localhost:11434',
+        modelName: 'gemma2:2b',
+        client: client,
+      );
+
+      final result = await gen.generate(
+        modelPath: '/ignored',
+        prompt: 'test prompt',
+        maxTokens: 300,
+        temperature: 0.3,
+      );
+
+      expect(result, equals('தமிழ் பதில்.'));
+      expect(captured, isNotNull);
+      expect(captured!.method, equals('POST'));
+      expect(captured!.url.toString(),
+          equals('http://localhost:11434/api/generate'));
+
+      final decoded = jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(decoded['model'], equals('gemma2:2b'));
+      expect(decoded['prompt'], equals('test prompt'));
+      expect(decoded['stream'], equals(false));
+      expect((decoded['options'] as Map)['num_predict'], equals(300));
+      expect((decoded['options'] as Map)['temperature'], equals(0.3));
+    });
+
+    test('throws LlmException on non-200 status', () async {
+      final client = MockClient((request) async {
+        return http.Response('server boom', 500);
+      });
+      final gen = OllamaGenerator(client: client);
+
+      await expectLater(
+        gen.generate(
+          modelPath: '',
+          prompt: 'hi',
+          maxTokens: 100,
+          temperature: 0.3,
+        ),
+        throwsA(isA<LlmException>()),
+      );
+    });
+
+    test('throws LlmException when response field is missing', () async {
+      final client = MockClient((request) async {
+        return http.Response(jsonEncode({'done': true}), 200);
+      });
+      final gen = OllamaGenerator(client: client);
+
+      await expectLater(
+        gen.generate(
+          modelPath: '',
+          prompt: 'hi',
+          maxTokens: 100,
+          temperature: 0.3,
+        ),
+        throwsA(isA<LlmException>()),
+      );
+    });
+
+    test('throws LlmException when response field is empty', () async {
+      final client = MockClient((request) async {
+        return http.Response(jsonEncode({'response': ''}), 200);
+      });
+      final gen = OllamaGenerator(client: client);
+
+      await expectLater(
+        gen.generate(
+          modelPath: '',
+          prompt: 'hi',
+          maxTokens: 100,
+          temperature: 0.3,
+        ),
+        throwsA(isA<LlmException>()),
+      );
+    });
+
+    test('defaults baseUrl and modelName from LlmConstants', () async {
+      http.Request? captured;
+      final client = MockClient((request) async {
+        captured = request;
+        return http.Response(jsonEncode({'response': 'ok'}), 200);
+      });
+      final gen = OllamaGenerator(client: client);
+
+      await gen.generate(
+        modelPath: '',
+        prompt: 'p',
+        maxTokens: 1,
+        temperature: 0.0,
+      );
+
+      expect(captured!.url.host, equals('localhost'));
+      expect(captured!.url.port, equals(11434));
+      final decoded = jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(decoded['model'], equals('gemma2:2b'));
+    });
+  });
+}

--- a/test/services/llm/prompt_builder_test.dart
+++ b/test/services/llm/prompt_builder_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+import 'package:nilam_ai/services/llm/prompt_builder.dart';
+
+void main() {
+  group('PromptBuilder.build', () {
+    test('injects query into the prompt', () {
+      final built = PromptBuilder.build(query: 'நெல் பயிர் நோய்?');
+      expect(built.text, contains('கேள்வி: நெல் பயிர் நோய்?'));
+      expect(built.query, equals('நெல் பயிர் நோய்?'));
+    });
+
+    test('includes Tamil system and instruction lines', () {
+      final built = PromptBuilder.build(query: 'test');
+      expect(built.text, contains('நிலம்AI'));
+      expect(built.text, contains('தமிழில் சுருக்கமாக'));
+    });
+
+    test('injects crop line when cropType is provided', () {
+      final built = PromptBuilder.build(query: 'query', cropType: 'நெல்');
+      expect(built.text, contains('பயிர்: நெல்'));
+    });
+
+    test('omits crop line when cropType is null', () {
+      final built = PromptBuilder.build(query: 'query');
+      expect(built.text.contains('பயிர்:'), isFalse);
+    });
+
+    test('omits crop line when cropType is empty', () {
+      final built = PromptBuilder.build(query: 'query', cropType: '');
+      expect(built.text.contains('பயிர்:'), isFalse);
+    });
+
+    test('omits crop line when cropType is whitespace', () {
+      final built = PromptBuilder.build(query: 'query', cropType: '   ');
+      expect(built.text.contains('பயிர்:'), isFalse);
+    });
+
+    test('trims leading/trailing whitespace on query', () {
+      final built = PromptBuilder.build(query: '  hello  ');
+      expect(built.query, equals('hello'));
+      expect(built.text, contains('கேள்வி: hello'));
+    });
+
+    test('throws LlmException(E012) on empty query', () {
+      expect(
+        () => PromptBuilder.build(query: ''),
+        throwsA(
+          isA<LlmException>().having((e) => e.code, 'code', equals('E012')),
+        ),
+      );
+    });
+
+    test('throws LlmException(E012) on whitespace-only query', () {
+      expect(
+        () => PromptBuilder.build(query: '   \n\t  '),
+        throwsA(isA<LlmException>()),
+      );
+    });
+
+    test('preserves crop type trimming', () {
+      final built = PromptBuilder.build(query: 'q', cropType: '  நெல்  ');
+      expect(built.text, contains('பயிர்: நெல்'));
+      expect(built.text.contains('  நெல்  '), isFalse);
+    });
+  });
+}

--- a/test/services/llm/response_post_processor_test.dart
+++ b/test/services/llm/response_post_processor_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nilam_ai/services/llm/response_post_processor.dart';
+
+void main() {
+  group('ResponsePostProcessor.process — markdown stripping', () {
+    test('strips bold markers', () {
+      final out = ResponsePostProcessor.process('இது **முக்கியம்** ஆகும்.');
+      expect(out, equals('இது முக்கியம் ஆகும்.'));
+    });
+
+    test('strips italic markers (underscore)', () {
+      final out = ResponsePostProcessor.process('hello _world_ today');
+      expect(out, equals('hello world today'));
+    });
+
+    test('strips headers', () {
+      final out = ResponsePostProcessor.process('## தலைப்பு\nதகவல்.');
+      expect(out, contains('தலைப்பு'));
+      expect(out.contains('##'), isFalse);
+    });
+
+    test('strips inline backticks', () {
+      final out = ResponsePostProcessor.process('Use `kubectl` command.');
+      // "kubectl" becomes whole-word after backtick strip — no abbreviation
+      // match (not in map).
+      expect(out.contains('`'), isFalse);
+      expect(out, contains('kubectl'));
+    });
+
+    test('strips fenced code blocks', () {
+      const input = 'Before\n```dart\nvoid main() {}\n```\nAfter';
+      final out = ResponsePostProcessor.process(input);
+      expect(out.contains('```'), isFalse);
+      expect(out.contains('void main'), isFalse);
+      expect(out, contains('Before'));
+      expect(out, contains('After'));
+    });
+
+    test('strips unordered list bullets', () {
+      const input = '- item one\n- item two\n* item three';
+      final out = ResponsePostProcessor.process(input);
+      expect(out, contains('item one'));
+      expect(out, contains('item two'));
+      expect(out, contains('item three'));
+      expect(out.contains('- '), isFalse);
+      expect(out.contains('* '), isFalse);
+    });
+
+    test('strips ordered list markers', () {
+      const input = '1. first\n2. second\n3. third';
+      final out = ResponsePostProcessor.process(input);
+      expect(out, contains('first'));
+      expect(out.contains('1.'), isFalse);
+      expect(out.contains('2.'), isFalse);
+    });
+
+    test('strips blockquotes', () {
+      final out = ResponsePostProcessor.process('> quoted text');
+      expect(out, equals('quoted text'));
+    });
+  });
+
+  group('ResponsePostProcessor.process — abbreviation expansion', () {
+    test('expands kg to கிலோ', () {
+      final out = ResponsePostProcessor.process('5 kg விதை போடு.');
+      expect(out, equals('5 கிலோ விதை போடு.'));
+    });
+
+    test('expands Rs to ரூபாய்', () {
+      final out = ResponsePostProcessor.process('விலை Rs 500.');
+      expect(out, contains('ரூபாய்'));
+      expect(out.contains(RegExp(r'\bRs\b')), isFalse);
+    });
+
+    test('expands ₹ currency symbol', () {
+      final out = ResponsePostProcessor.process('விலை ₹500.');
+      expect(out, contains('ரூபாய்'));
+      expect(out.contains('₹'), isFalse);
+    });
+
+    test('expands ha (hectare)', () {
+      final out = ResponsePostProcessor.process('1 ha நிலம்');
+      expect(out, contains('ஹெக்டேர்'));
+    });
+
+    test('does not expand abbreviations inside words', () {
+      // "kgf" should not have "kg" replaced.
+      final out = ResponsePostProcessor.process('kgfoobar');
+      expect(out, equals('kgfoobar'));
+    });
+  });
+
+  group('ResponsePostProcessor.process — whitespace', () {
+    test('preserves single paragraph breaks', () {
+      const input = 'Para one.\n\nPara two.';
+      final out = ResponsePostProcessor.process(input);
+      expect(out, equals('Para one.\n\nPara two.'));
+    });
+
+    test('collapses 3+ newlines to a single blank line', () {
+      const input = 'A.\n\n\n\n\nB.';
+      final out = ResponsePostProcessor.process(input);
+      expect(out, equals('A.\n\nB.'));
+    });
+
+    test('collapses runs of spaces', () {
+      final out = ResponsePostProcessor.process('too    many   spaces');
+      expect(out, equals('too many spaces'));
+    });
+
+    test('trims leading and trailing whitespace', () {
+      final out = ResponsePostProcessor.process('   \n\ntext\n\n   ');
+      expect(out, equals('text'));
+    });
+  });
+
+  group('ResponsePostProcessor.process — combined pipeline', () {
+    test('handles markdown + abbreviation + whitespace in one pass', () {
+      const input = '## தலைப்பு\n\n**5 kg** விதை போடு.\n\n\n- முதல் படி';
+      final out = ResponsePostProcessor.process(input);
+      expect(out, contains('தலைப்பு'));
+      expect(out, contains('5 கிலோ விதை போடு.'));
+      expect(out, contains('முதல் படி'));
+      expect(out.contains('##'), isFalse);
+      expect(out.contains('**'), isFalse);
+      expect(out.contains('- '), isFalse);
+    });
+
+    test('is idempotent on clean input', () {
+      const clean = 'சுத்தமான தமிழ் பதில்.';
+      expect(ResponsePostProcessor.process(clean), equals(clean));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the on-device Tamil LLM inference service for NilamAI (issue #6), mirroring the Phase 4 Whisper STT architecture so the codebase stays coherent. **UI wiring is out of scope** and tracked separately in #15 — this PR is service + tests only.

- `GemmaService` orchestrates: load model → build Tamil prompt → generate (30s timeout) → post-process → return `GemmaResponse` (text, rawText, prompt, latencyMs)
- `GemmaGenerator` abstract with two impls: `FlutterGemmaGenerator` (prod, LiteRT-LM via `flutter_gemma`) and `OllamaGenerator` (dev/demo HTTP bridge, aligns with SRS Ollama Prize integration)
- `PromptBuilder` / `ResponsePostProcessor` — Tamil system prompt with optional crop-type context; strips markdown and expands unit abbreviations (kg → கிலோ, etc.)
- `GemmaModelLoader` — copies the 1.3 GB `.litertlm` asset to app-dir on first run; caches path
- `LlmException` factories for E009–E012 (model not loaded / timeout / OOM / invalid query)
- `GemmaNotifier` sealed state machine: Idle → LoadingModel → Generating → Complete / Error
- Fetch scripts (`scripts/fetch_gemma_model.{sh,ps1}`) for the HuggingFace checkpoint; gitignored like the Whisper model (HF revision is not yet pinned in SRS §8 — flagged as a pre-release TODO in both scripts)

### Non-obvious items

- **SRS 1.0 overrides issue #6 where they conflict**: `.litertlm` (not `.bin`), 300 max output tokens (not 256), temperature 0.3, coverage target ≥70% (not 60%)
- **`android/gradle.properties` sets `kotlin.incremental=false`** — workaround for the cross-drive Kotlin cache bug (`IllegalArgumentException: this and base files have different roots`) triggered by the new `large_file_handler` / `background_downloader` transitive deps when the Pub cache is on a different drive than the project. Costs a few seconds per build but is required for cross-drive Windows setups.
- **No DB writes inside `GemmaService`** — caller (set up in #15) handles `QueryHistoryDao.update` + provider invalidation. Keeps the service sqflite-free and easy to test.

### Test coverage

- **251/251 tests pass** (no Phase 4/5a regressions)
- **`lib/services/llm/` coverage: 77.4%** (SRS NFR-7.2 target ≥70%)
  - `gemma_service.dart` 100%, `response_post_processor.dart` 96.6%, `gemma_model_loader.dart` 96.0%, `prompt_builder.dart` 90.0%
  - `gemma_generator.dart` 33% — `OllamaGenerator` is fully tested (with `MockClient`); `FlutterGemmaGenerator` is thin native delegation, manual smoke only per plan §5
- Tests use custom fake classes (no mocktail/mockito), matching the Whisper testing convention

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 251/251 pass
- [x] `flutter test --coverage` — `lib/services/llm/` = 77.4% (target ≥70%)
- [x] Manual run on moto g34 5G — Phase 4/5a flow (record → transcribe → persist) works end-to-end; Gemma service is bundled but not yet invoked (wiring in #15)
- [ ] Pin the HuggingFace checkpoint URL in `scripts/fetch_gemma_model.*` before release (flagged as TODO in both scripts)
- [ ] Manual Ollama bridge smoke test (dev-only, optional)
- [ ] Device smoke: fetch the 1.3 GB model + APK build + first-run model copy (blocked on the URL pin; belongs to Phase 8 anyway)

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)