### PR TITLE
Pin Gemma model fetch to HF revision 2a101e0 + SHA256 check

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [docs/srs_1.0.md](docs/srs_1.0.md) for the canonical spec.
 The app ships two on-device models that are **not** committed to git:
 
 - `ggml-base-q8_0.bin` (~75 MB) — Whisper Tamil STT (Phase 4)
-- `gemma_4_e2b_int4.litertlm` (~1.3 GB) — Gemma 4 E2B INT4 LLM (Phase 6)
+- `gemma-4-E2B-it.litertlm` (~2.6 GB) — Gemma 4 E2B LLM (Phase 6)
 
 Fetch both once after cloning, before running `flutter run`:
 

--- a/lib/services/llm/llm_constants.dart
+++ b/lib/services/llm/llm_constants.dart
@@ -1,8 +1,9 @@
 /// Gemma LLM configuration constants for NilamAI.
 ///
-/// Uses Gemma 4 E2B INT4 quantized model (~1.3 GB, `.litertlm` format).
-/// Bundled in the APK via `assets/models/` and copied to app documents on
-/// first launch by [GemmaModelLoader].
+/// Uses Gemma 4 E2B model (~2.6 GB, `.litertlm` format) from
+/// litert-community/gemma-4-E2B-it-litert-lm. Bundled in the APK via
+/// `assets/models/` and copied to app documents on first launch by
+/// [GemmaModelLoader].
 ///
 /// Values follow `docs/srs_1.0.md` §8 (revised 2026-04-16) where they differ
 /// from GitHub issue #6.
@@ -11,8 +12,8 @@ class LlmConstants {
 
   // -- Model --
   static const String modelAssetPath =
-      'assets/models/gemma_4_e2b_int4.litertlm';
-  static const String modelFileName = 'gemma_4_e2b_int4.litertlm';
+      'assets/models/gemma-4-E2B-it.litertlm';
+  static const String modelFileName = 'gemma-4-E2B-it.litertlm';
   static const String modelsSubDir = 'models';
 
   // -- Inference --

--- a/scripts/fetch_gemma_model.ps1
+++ b/scripts/fetch_gemma_model.ps1
@@ -1,19 +1,19 @@
 #!/usr/bin/env pwsh
-# Fetches the Gemma 4 E2B INT4 model (.litertlm, ~1.3 GB) for NilamAI.
+# Fetches the Gemma 4 E2B model (.litertlm, ~2.6 GB) for NilamAI.
 # Run once after cloning: pwsh scripts/fetch_gemma_model.ps1
 # Required for Phase 6 on-device LLM inference.
 #
-# NOTE: The exact HuggingFace revision is not yet pinned in SRS §8. The
-# checkpoint below is the reference `litert-community/gemma-4-E2B-it-litert-lm`
-# repo; confirm availability and swap in the pinned revision before release.
-# See: docs/srs_1.0.md §8 (Model Strategy) and GitHub issue #6.
+# Pinned to HuggingFace revision 2a101e0 (2026-04-07) of
+# litert-community/gemma-4-E2B-it-litert-lm. Bumping the pin is a conscious
+# change — update $modelUrl and $expectedSha256 together.
 
 $ErrorActionPreference = 'Stop'
-$modelUrl = 'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma_4_e2b_int4.litertlm'
+$modelUrl = 'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/2a101e00c47f942975ce8b493c2498311ed9900d/gemma-4-E2B-it.litertlm'
+$expectedSha256 = 'ab7838cdfc8f77e54d8ca45eadceb20452d9f01e4bfade03e5dce27911b27e42'
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path -Parent $scriptDir
 $targetDir = Join-Path $repoRoot 'assets\models'
-$targetFile = Join-Path $targetDir 'gemma_4_e2b_int4.litertlm'
+$targetFile = Join-Path $targetDir 'gemma-4-E2B-it.litertlm'
 $minBytes = 1GB
 
 if (-not (Test-Path $targetDir)) {
@@ -26,9 +26,21 @@ if ((Test-Path $targetFile) -and (Get-Item $targetFile).Length -gt $minBytes) {
     exit 0
 }
 
-Write-Host "Downloading gemma_4_e2b_int4.litertlm (~1.3 GB) from Huggingface..."
+Write-Host "Downloading gemma-4-E2B-it.litertlm (~2.6 GB) from Huggingface..."
 Write-Host "  URL: $modelUrl"
-Write-Host "  If this fails, the checkpoint may have moved — see docs/srs_1.0.md §8."
 Invoke-WebRequest -Uri $modelUrl -OutFile $targetFile
-$sizeMb = '{0:N0}' -f ((Get-Item $targetFile).Length / 1MB)
+
+$downloadedBytes = (Get-Item $targetFile).Length
+if ($downloadedBytes -lt $minBytes) {
+    Remove-Item $targetFile
+    throw "Download too small ($('{0:N0}' -f ($downloadedBytes / 1MB)) MB) — likely a 404 HTML page."
+}
+
+$actual = (Get-FileHash -Algorithm SHA256 -Path $targetFile).Hash.ToLower()
+if ($actual -ne $expectedSha256.ToLower()) {
+    Remove-Item $targetFile
+    throw "SHA256 mismatch for $targetFile`n  expected: $expectedSha256`n  actual:   $actual"
+}
+
+$sizeMb = '{0:N0}' -f ($downloadedBytes / 1MB)
 Write-Host "Downloaded $sizeMb MB to $targetFile"

--- a/scripts/fetch_gemma_model.sh
+++ b/scripts/fetch_gemma_model.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
-# Fetches the Gemma 4 E2B INT4 model (.litertlm, ~1.3 GB) for NilamAI.
+# Fetches the Gemma 4 E2B model (.litertlm, ~2.6 GB) for NilamAI.
 # Run once after cloning: bash scripts/fetch_gemma_model.sh
 # Required for Phase 6 on-device LLM inference.
 #
-# NOTE: The exact HuggingFace revision is not yet pinned in SRS §8. The
-# checkpoint below is the reference `litert-community/gemma-4-E2B-it-litert-lm`
-# repo; confirm availability and swap in the pinned revision before release.
-# See: docs/srs_1.0.md §8 (Model Strategy) and GitHub issue #6.
+# Pinned to HuggingFace revision 2a101e0 (2026-04-07) of
+# litert-community/gemma-4-E2B-it-litert-lm. Bumping the pin is a conscious
+# change — update MODEL_URL and EXPECTED_SHA256 together.
 
 set -euo pipefail
 
-MODEL_URL='https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma_4_e2b_int4.litertlm'
+MODEL_URL='https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/2a101e00c47f942975ce8b493c2498311ed9900d/gemma-4-E2B-it.litertlm'
+EXPECTED_SHA256='ab7838cdfc8f77e54d8ca45eadceb20452d9f01e4bfade03e5dce27911b27e42'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 TARGET_DIR="$REPO_ROOT/assets/models"
-TARGET_FILE="$TARGET_DIR/gemma_4_e2b_int4.litertlm"
+TARGET_FILE="$TARGET_DIR/gemma-4-E2B-it.litertlm"
 MIN_BYTES=$((1024 * 1024 * 1024)) # 1 GB sanity threshold
 
 mkdir -p "$TARGET_DIR"
@@ -27,9 +27,8 @@ if [ -f "$TARGET_FILE" ]; then
     fi
 fi
 
-echo "Downloading gemma_4_e2b_int4.litertlm (~1.3 GB) from Huggingface..."
+echo "Downloading gemma-4-E2B-it.litertlm (~2.6 GB) from Huggingface..."
 echo "  URL: $MODEL_URL"
-echo "  If this fails, the checkpoint may have moved — see docs/srs_1.0.md §8."
 if command -v curl >/dev/null; then
     curl -L -o "$TARGET_FILE" "$MODEL_URL"
 elif command -v wget >/dev/null; then
@@ -40,4 +39,26 @@ else
 fi
 
 downloaded_size="$(stat -c%s "$TARGET_FILE" 2>/dev/null || stat -f%z "$TARGET_FILE")"
+if [ "$downloaded_size" -lt "$MIN_BYTES" ]; then
+    echo "ERROR: download too small ($((downloaded_size / 1024 / 1024)) MB) — likely a 404 HTML page." >&2
+    rm -f "$TARGET_FILE"
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null; then
+    actual="$(sha256sum "$TARGET_FILE" | awk '{print $1}')"
+elif command -v shasum >/dev/null; then
+    actual="$(shasum -a 256 "$TARGET_FILE" | awk '{print $1}')"
+else
+    echo "No sha256sum or shasum available — skipping integrity check." >&2
+    actual=""
+fi
+if [ -n "$actual" ] && [ "$actual" != "$EXPECTED_SHA256" ]; then
+    echo "ERROR: SHA256 mismatch for $TARGET_FILE" >&2
+    echo "  expected: $EXPECTED_SHA256" >&2
+    echo "  actual:   $actual" >&2
+    rm -f "$TARGET_FILE"
+    exit 1
+fi
+
 echo "Downloaded $((downloaded_size / 1024 / 1024)) MB to $TARGET_FILE"


### PR DESCRIPTION
## Summary
- Fetch scripts pointed at `gemma_4_e2b_int4.litertlm` on `/resolve/main/`, which 404s — that filename no longer exists upstream. Swap to `gemma-4-E2B-it.litertlm` (2.58 GB, canonical cross-platform build) pinned to commit `2a101e0` of `litert-community/gemma-4-E2B-it-litert-lm`.
- Add SHA256 verification after download (bash + PowerShell); hard-fail on mismatch, delete the bad file.
- Add a size sanity check post-download (catches 404 HTML bodies that slipped past the old "min 1 GB" gate).
- Rename `modelFileName` / `modelAssetPath` in `LlmConstants` and update the README line to match.

## Why
Before this PR: `bash scripts/fetch_gemma_model.sh` silently fetched a 15-byte 404 page and failed hash-free. On-device, the app then hit E009 "model not loaded" because `assets/models/` was empty at build time. Builds were also not reproducible — `/resolve/main/` tracks whatever HuggingFace serves today.

## Pinned values
- Revision: `2a101e00c47f942975ce8b493c2498311ed9900d` (modified 2026-04-07)
- File SHA256: `ab7838cdfc8f77e54d8ca45eadceb20452d9f01e4bfade03e5dce27911b27e42`
- Size: 2,583,085,056 bytes (2.58 GB)

## Follow-up (not in this PR)
Upstream's 2.58 GB exceeds SRS §8's 1.3 GB assumption and the Play Store 2.5 GB monolithic-APK cap. Tracked separately in #22 — that issue will decide between Play Asset Delivery, a smaller quantization, or deferring.

## Test plan
- [x] `flutter analyze` — clean (no usages of the old constants linger)
- [x] Bash script: fresh fetch against pinned URL produces the expected 2.58 GB file with matching SHA256
- [x] Bash script: idempotent re-run (exits 0, "already present")
- [x] Bash script: mismatch branch exercised with a fake file — prints expected/actual, removes file, exits 1
- [ ] PowerShell script: re-run on Windows (PS 5.1) — not executed in CI; logic symmetric to bash
- [ ] Device smoke on moto g34 5G — requires rebuilding the APK with the 2.58 GB model bundled (deferred to the #22 follow-up since the bundling strategy is in flux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)