### PR TITLE
Phase 7: Swap on-device Gemma for Google Gemini API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# NilamAI environment variables.
+# Copy this file to `.env` and fill in your values.
+# `.env` is gitignored — never commit real keys.
+#
+# Get a Gemini API key from https://aistudio.google.com/apikey
+GEMINI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,39 +1,57 @@
 # NilamAI (நிலம்AI)
 
-Offline-first Tamil agricultural advisory app for smallholder farmers in Tamil Nadu.
-See [docs/srs_1.0.md](docs/srs_1.0.md) for the canonical spec.
+Tamil agricultural advisory app for smallholder farmers in Tamil Nadu. STT
+runs on-device (Whisper); the LLM currently runs via the Google Gemini API
+(the bundled 2.58 GB on-device Gemma 4 E2B OOM-killed 4 GB RAM devices — see
+[Phase 7 plan](C:/Users/email/.claude/plans/create-complete-implemenaion-plan-glowing-crown.md)).
+Full spec: [docs/srs_1.0.md](docs/srs_1.0.md).
 
 ## Prerequisites
 
 - Flutter 3.24+ / Dart SDK ^3.10.4
-- `curl` or `wget` (for fetch scripts on macOS/Linux), PowerShell on Windows
-- ~3 GB of free disk space for bundled models
+- `curl` or `wget` (macOS/Linux) or PowerShell (Windows) for the Whisper model fetch
+- A Google Gemini API key — free tier from https://aistudio.google.com/apikey
 
 ## First-time setup
 
-The app ships two on-device models that are **not** committed to git:
-
-- `ggml-base-q8_0.bin` (~75 MB) — Whisper Tamil STT (Phase 4)
-- `gemma_4_e2b_int4.litertlm` (~1.3 GB) — Gemma 4 E2B INT4 LLM (Phase 6)
-
-Fetch both once after cloning, before running `flutter run`:
+Fetch the on-device Whisper STT model (not committed to git):
 
 ```bash
 # macOS / Linux
 bash scripts/fetch_model.sh
-bash scripts/fetch_gemma_model.sh
 
 # Windows (PowerShell)
 pwsh scripts/fetch_model.ps1
-pwsh scripts/fetch_gemma_model.ps1
 ```
 
-Then:
+Install Flutter deps:
 
 ```bash
 flutter pub get
+```
+
+Create your `.env` file from the template and fill in your Gemini key:
+
+```bash
+cp .env.example .env
+# then edit .env and set GEMINI_API_KEY=<your-key>
+```
+
+`.env` is gitignored — never commit real keys. Run the app:
+
+```bash
 flutter run
 ```
+
+For release builds that shouldn't ship a `.env` (e.g. CI), pass the key at
+build time instead:
+
+```bash
+flutter build apk --release --dart-define=GEMINI_API_KEY=<your-key>
+```
+
+`LlmConstants.geminiApiKey` reads `.env` first, then falls back to the
+`--dart-define` value.
 
 ## Testing
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -35,6 +35,11 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
+            // flutter_gemma uses reflection into MediaPipe proto classes; R8 can't
+            // see those references statically and strips them. Disabling shrinking
+            // avoids maintaining a long list of -keep/-dontwarn rules.
+            isMinifyEnabled = false
+            isShrinkResources = false
         }
     }
 }

--- a/lib/core/exceptions/app_exception.dart
+++ b/lib/core/exceptions/app_exception.dart
@@ -13,6 +13,7 @@
 /// - E010: Gemma inference timeout (>30s)
 /// - E011: Gemma out of memory during inference
 /// - E012: Invalid query for Gemma
+/// - E013: LLM network offline (API mode)
 sealed class AppException implements Exception {
   const AppException({
     required this.code,
@@ -95,6 +96,13 @@ class LlmException extends AppException {
       : this(
           code: 'E012',
           message: 'Invalid query for Gemma: $detail',
+        );
+
+  LlmException.networkOffline({Object? originalError})
+      : this(
+          code: 'E013',
+          message: 'No internet connection — try again when online',
+          originalError: originalError,
         );
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -11,6 +12,12 @@ import 'services/database/database_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  try {
+    await dotenv.load(fileName: '.env');
+  } catch (e) {
+    AppLogger.error('.env load failed — continuing with empty env', 'main', e);
+  }
 
   final dbService = DatabaseService.create();
   try {

--- a/lib/providers/llm_providers.dart
+++ b/lib/providers/llm_providers.dart
@@ -1,10 +1,14 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/exceptions/app_exception.dart';
 import '../core/logging/logger.dart';
+import '../services/llm/gemini_generator.dart';
 import '../services/llm/gemma_generator.dart';
 import '../services/llm/gemma_model_loader.dart';
 import '../services/llm/gemma_service.dart';
+import '../services/llm/llm_constants.dart';
+import '../services/llm/noop_model_loader.dart';
 
 // -----------------------------------------------------------------------------
 // Sealed Gemma state
@@ -43,20 +47,39 @@ class GemmaError extends GemmaState {
 // Providers
 // -----------------------------------------------------------------------------
 
+/// API-mode loader — returns an empty path; the remote [GeminiGenerator]
+/// ignores it. Swap back to [GemmaModelLoader] when reviving on-device mode.
 final gemmaModelLoaderProvider = Provider<GemmaModelLoader>((ref) {
-  return GemmaModelLoader();
+  return NoopModelLoader();
 });
 
-/// Production generator. Override with [OllamaGenerator] for dev, or with a
-/// fake for tests.
+/// Production generator. Currently Gemini REST because the 2.58 GB
+/// `.litertlm` model OOM-kills 4 GB devices (see Phase 6 post-mortem).
+/// Override with [OllamaGenerator] for dev, [FlutterGemmaGenerator] for
+/// on-device hybrid mode, or a fake for tests.
 final gemmaGeneratorProvider = Provider<GemmaGenerator>((ref) {
-  return FlutterGemmaGenerator();
+  if (LlmConstants.geminiApiKey.isEmpty) {
+    throw StateError(
+      'GEMINI_API_KEY is not set. Run: flutter run '
+      '--dart-define=GEMINI_API_KEY=<your-key>. '
+      'Get a key at https://aistudio.google.com/apikey',
+    );
+  }
+  return GeminiGenerator(apiKey: LlmConstants.geminiApiKey);
+});
+
+/// Connectivity probe wired into [GemmaService]. Defaults to the real
+/// `connectivity_plus` plugin; tests override this with `null` to skip the
+/// pre-flight network check (or a fake to exercise the offline path).
+final connectivityCheckProvider = Provider<ConnectivityCheck?>((ref) {
+  return Connectivity().checkConnectivity;
 });
 
 final gemmaServiceProvider = Provider<GemmaService>((ref) {
   return GemmaService(
     loader: ref.watch(gemmaModelLoaderProvider),
     generator: ref.watch(gemmaGeneratorProvider),
+    connectivityCheck: ref.watch(connectivityCheckProvider),
   );
 });
 

--- a/lib/services/llm/gemini_generator.dart
+++ b/lib/services/llm/gemini_generator.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+import '../../core/exceptions/app_exception.dart';
+import '../../core/logging/logger.dart';
+import 'gemma_generator.dart';
+import 'llm_constants.dart';
+
+/// Production LLM backend that calls Google's Gemini `generateContent` REST
+/// endpoint. Replaces the on-device `FlutterGemmaGenerator` on 4 GB RAM
+/// devices where the 2.58 GB `.litertlm` model OOM-kills the app.
+///
+/// Implements the same [GemmaGenerator] contract as the on-device and Ollama
+/// paths so callers (`GemmaService`, providers, the UI state machine) do not
+/// change. The `modelPath` argument is ignored; Gemini hosts the model.
+class GeminiGenerator implements GemmaGenerator {
+  GeminiGenerator({
+    required this.apiKey,
+    String? baseUrl,
+    String? model,
+    http.Client? client,
+  })  : baseUrl = baseUrl ?? LlmConstants.geminiBaseUrl,
+        model = model ?? LlmConstants.geminiModel,
+        _client = client ?? http.Client();
+
+  static const _tag = 'GeminiGenerator';
+
+  final String apiKey;
+  final String baseUrl;
+  final String model;
+  final http.Client _client;
+
+  @override
+  Future<String> generate({
+    required String modelPath,
+    required String prompt,
+    required int maxTokens,
+    required double temperature,
+  }) async {
+    final uri = Uri.parse('$baseUrl/$model:generateContent?key=$apiKey');
+    final body = jsonEncode({
+      'contents': [
+        {
+          'parts': [
+            {'text': prompt},
+          ],
+        },
+      ],
+      'generationConfig': {
+        'maxOutputTokens': maxTokens,
+        'temperature': temperature,
+      },
+    });
+
+    final http.Response response;
+    try {
+      response = await _client
+          .post(
+            uri,
+            headers: const {'Content-Type': 'application/json'},
+            body: body,
+          )
+          .timeout(
+            const Duration(seconds: LlmConstants.inferenceTimeoutSeconds),
+          );
+    } on TimeoutException catch (e) {
+      throw LlmException.inferenceTimeout(originalError: e);
+    } on SocketException catch (e) {
+      throw LlmException.networkOffline(originalError: e);
+    } on http.ClientException catch (e) {
+      throw LlmException.networkOffline(originalError: e);
+    }
+
+    if (response.statusCode != 200) {
+      final bodyText = utf8.decode(response.bodyBytes, allowMalformed: true);
+      AppLogger.error(
+        'Gemini HTTP ${response.statusCode}: $bodyText',
+        _tag,
+      );
+      throw LlmException(
+        message: 'Gemini returned HTTP ${response.statusCode}: $bodyText',
+      );
+    }
+
+    // Decode as UTF-8 directly — matches OllamaGenerator for correct Tamil.
+    final Map<String, dynamic> decoded;
+    try {
+      decoded = jsonDecode(utf8.decode(response.bodyBytes))
+          as Map<String, dynamic>;
+    } catch (e) {
+      throw LlmException.modelNotLoaded(originalError: e);
+    }
+
+    final candidates = decoded['candidates'];
+    if (candidates is! List || candidates.isEmpty) {
+      throw const LlmException(
+        message: 'Gemini response missing "candidates"',
+        code: 'E009',
+      );
+    }
+
+    final content = (candidates.first as Map<String, dynamic>)['content'];
+    final parts = (content is Map<String, dynamic>) ? content['parts'] : null;
+    if (parts is! List || parts.isEmpty) {
+      throw const LlmException(
+        message: 'Gemini response missing "content.parts"',
+        code: 'E009',
+      );
+    }
+
+    final text = (parts.first as Map<String, dynamic>)['text'];
+    if (text is! String || text.isEmpty) {
+      throw const LlmException(
+        message: 'Gemini response missing text',
+        code: 'E009',
+      );
+    }
+    return text;
+  }
+
+  /// Test-only — closes the underlying HTTP client.
+  void close() => _client.close();
+}

--- a/lib/services/llm/gemma_service.dart
+++ b/lib/services/llm/gemma_service.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
+
 import '../../core/exceptions/app_exception.dart';
 import '../../core/logging/logger.dart';
 import 'gemma_generator.dart';
@@ -7,6 +9,12 @@ import 'gemma_model_loader.dart';
 import 'llm_constants.dart';
 import 'prompt_builder.dart';
 import 'response_post_processor.dart';
+
+/// Async connectivity probe; returns the current transports (wifi, mobile,
+/// ethernet, vpn, or none). Injected so tests can run without the real
+/// connectivity plugin. Null means "skip the check" — used by existing
+/// tests that predate the remote (API) backend.
+typedef ConnectivityCheck = Future<List<ConnectivityResult>> Function();
 
 /// Outcome of a successful Gemma inference.
 ///
@@ -39,19 +47,23 @@ class GemmaService {
   GemmaService({
     required GemmaModelLoader loader,
     required GemmaGenerator generator,
+    ConnectivityCheck? connectivityCheck,
   })  : _loader = loader,
-        _generator = generator;
+        _generator = generator,
+        _connectivityCheck = connectivityCheck;
 
   static const _tag = 'GemmaService';
 
   final GemmaModelLoader _loader;
   final GemmaGenerator _generator;
+  final ConnectivityCheck? _connectivityCheck;
 
   /// Generates a Tamil response for [query], optionally contextualized with
   /// [cropType] from the user profile.
   ///
   /// Error handling (SRS §10.3):
   /// - [LlmException.invalidQuery] (E012) — empty/whitespace query
+  /// - [LlmException.networkOffline] (E013) — device offline in API mode
   /// - [LlmException.modelNotLoaded] (E009) — model asset missing or I/O error
   /// - [LlmException.inferenceTimeout] (E010) — >30 s without a response
   /// - [LlmException.outOfMemory] (E011) — OOM during inference
@@ -61,6 +73,13 @@ class GemmaService {
   }) async {
     // PromptBuilder throws E012 on empty/whitespace.
     final built = PromptBuilder.build(query: query, cropType: cropType);
+
+    if (_connectivityCheck != null) {
+      final status = await _connectivityCheck();
+      if (status.every((c) => c == ConnectivityResult.none)) {
+        throw LlmException.networkOffline();
+      }
+    }
 
     final String modelPath;
     try {

--- a/lib/services/llm/llm_constants.dart
+++ b/lib/services/llm/llm_constants.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
 /// Gemma LLM configuration constants for NilamAI.
 ///
 /// Uses Gemma 4 E2B INT4 quantized model (~1.3 GB, `.litertlm` format).
@@ -24,6 +26,20 @@ class LlmConstants {
   // -- Ollama dev bridge --
   static const String ollamaDefaultUrl = 'http://localhost:11434';
   static const String ollamaDefaultModel = 'gemma2:2b';
+
+  // -- Gemini API (production backend) --
+  static const String geminiBaseUrl =
+      'https://generativelanguage.googleapis.com/v1beta/models';
+  static const String geminiModel = 'gemini-2.5-flash';
+
+  /// Loaded from `.env` (see `.env.example`) at app start via `dotenv.load()`.
+  /// Falls back to the compile-time `--dart-define=GEMINI_API_KEY=...` if set
+  /// so CI and release builds can still inject a key without a `.env` file.
+  static String get geminiApiKey {
+    final fromDotenv = dotenv.maybeGet('GEMINI_API_KEY') ?? '';
+    if (fromDotenv.isNotEmpty) return fromDotenv;
+    return const String.fromEnvironment('GEMINI_API_KEY', defaultValue: '');
+  }
 
   // -- Language --
   static const String language = 'ta';

--- a/lib/services/llm/noop_model_loader.dart
+++ b/lib/services/llm/noop_model_loader.dart
@@ -1,0 +1,13 @@
+import 'gemma_model_loader.dart';
+
+/// Stand-in for [GemmaModelLoader] when the active generator is remote
+/// (e.g. [GeminiGenerator]). Skips the 2.6 GB asset copy entirely and
+/// returns an empty path that the remote generator ignores.
+///
+/// Wired via the provider layer in API mode; keeps `GemmaService` unchanged.
+class NoopModelLoader extends GemmaModelLoader {
+  NoopModelLoader() : super();
+
+  @override
+  Future<String> ensureModelAvailable() async => '';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
   package_info_plus: ^8.0.0
   http: ^1.2.0
   flutter_gemma: ^0.12.6
+  connectivity_plus: ^6.0.0
+  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:
@@ -39,3 +41,4 @@ flutter:
   uses-material-design: true
   assets:
     - assets/models/
+    - .env

--- a/test/providers/llm_providers_test.dart
+++ b/test/providers/llm_providers_test.dart
@@ -65,6 +65,7 @@ void main() {
           gemmaGeneratorProvider.overrideWithValue(
             _FakeGenerator(text: 'சுத்தமான பதில்.'),
           ),
+          connectivityCheckProvider.overrideWithValue(null),
         ],
       );
 
@@ -96,6 +97,7 @@ void main() {
           gemmaModelLoaderProvider
               .overrideWithValue(_FakeLoader(shouldThrow: true)),
           gemmaGeneratorProvider.overrideWithValue(_FakeGenerator()),
+          connectivityCheckProvider.overrideWithValue(null),
         ],
       );
 
@@ -113,6 +115,7 @@ void main() {
         overrides: [
           gemmaModelLoaderProvider.overrideWithValue(_FakeLoader()),
           gemmaGeneratorProvider.overrideWithValue(_FakeGenerator()),
+          connectivityCheckProvider.overrideWithValue(null),
         ],
       );
 
@@ -130,6 +133,7 @@ void main() {
         overrides: [
           gemmaModelLoaderProvider.overrideWithValue(_FakeLoader()),
           gemmaGeneratorProvider.overrideWithValue(_FakeGenerator()),
+          connectivityCheckProvider.overrideWithValue(null),
         ],
       );
 

--- a/test/services/llm/gemini_generator_test.dart
+++ b/test/services/llm/gemini_generator_test.dart
@@ -1,0 +1,185 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:nilam_ai/core/exceptions/app_exception.dart';
+import 'package:nilam_ai/services/llm/gemini_generator.dart';
+
+http.Response _json(Object body, [int status = 200]) => http.Response.bytes(
+      utf8.encode(jsonEncode(body)),
+      status,
+      headers: const {'content-type': 'application/json; charset=utf-8'},
+    );
+
+void main() {
+  group('GeminiGenerator.generate', () {
+    test('POSTs prompt to v1beta endpoint and returns Tamil text', () async {
+      http.Request? captured;
+      final client = MockClient((request) async {
+        captured = request;
+        return _json({
+          'candidates': [
+            {
+              'content': {
+                'parts': [
+                  {'text': 'தக்காளிச் செடிக்கு நீம் எண்ணெய் பயன்படுத்துங்கள்.'},
+                ],
+              },
+            },
+          ],
+        });
+      });
+
+      final gen = GeminiGenerator(
+        apiKey: 'test-key',
+        model: 'gemini-1.5-flash-latest',
+        client: client,
+      );
+
+      final result = await gen.generate(
+        modelPath: '/ignored',
+        prompt: 'test prompt',
+        maxTokens: 300,
+        temperature: 0.3,
+      );
+
+      expect(
+        result,
+        equals('தக்காளிச் செடிக்கு நீம் எண்ணெய் பயன்படுத்துங்கள்.'),
+      );
+      expect(captured, isNotNull);
+      expect(captured!.method, equals('POST'));
+      expect(captured!.url.host, equals('generativelanguage.googleapis.com'));
+      expect(
+        captured!.url.path,
+        equals('/v1beta/models/gemini-1.5-flash-latest:generateContent'),
+      );
+      expect(captured!.url.queryParameters['key'], equals('test-key'));
+
+      final decoded = jsonDecode(captured!.body) as Map<String, dynamic>;
+      final parts =
+          ((decoded['contents'] as List).first as Map)['parts'] as List;
+      expect((parts.first as Map)['text'], equals('test prompt'));
+      final cfg = decoded['generationConfig'] as Map;
+      expect(cfg['maxOutputTokens'], equals(300));
+      expect(cfg['temperature'], equals(0.3));
+    });
+
+    test('throws LlmException on non-200 status (e.g. 400 auth)', () async {
+      final client = MockClient((request) async {
+        return http.Response('bad api key', 400);
+      });
+      final gen = GeminiGenerator(apiKey: 'bad-key', client: client);
+
+      await expectLater(
+        gen.generate(
+          modelPath: '',
+          prompt: 'hi',
+          maxTokens: 100,
+          temperature: 0.3,
+        ),
+        throwsA(isA<LlmException>()),
+      );
+    });
+
+    test('maps SocketException to networkOffline (E013)', () async {
+      final client = MockClient((request) async {
+        throw const SocketException('no route to host');
+      });
+      final gen = GeminiGenerator(apiKey: 'k', client: client);
+
+      try {
+        await gen.generate(
+          modelPath: '',
+          prompt: 'hi',
+          maxTokens: 100,
+          temperature: 0.3,
+        );
+        fail('expected LlmException');
+      } on LlmException catch (e) {
+        expect(e.code, equals('E013'));
+      }
+    });
+
+    test('maps TimeoutException to inferenceTimeout (E010)', () async {
+      final client = MockClient((request) async {
+        throw TimeoutException('slow');
+      });
+      final gen = GeminiGenerator(apiKey: 'k', client: client);
+
+      try {
+        await gen.generate(
+          modelPath: '',
+          prompt: 'hi',
+          maxTokens: 100,
+          temperature: 0.3,
+        );
+        fail('expected LlmException');
+      } on LlmException catch (e) {
+        expect(e.code, equals('E010'));
+      }
+    });
+
+    test('throws when candidates array is empty', () async {
+      final client = MockClient((request) async {
+        return _json({'candidates': <Object>[]});
+      });
+      final gen = GeminiGenerator(apiKey: 'k', client: client);
+
+      await expectLater(
+        gen.generate(
+          modelPath: '',
+          prompt: 'hi',
+          maxTokens: 100,
+          temperature: 0.3,
+        ),
+        throwsA(isA<LlmException>()),
+      );
+    });
+
+    test('throws on malformed JSON body', () async {
+      final client = MockClient((request) async {
+        return http.Response('<html>oops</html>', 200);
+      });
+      final gen = GeminiGenerator(apiKey: 'k', client: client);
+
+      await expectLater(
+        gen.generate(
+          modelPath: '',
+          prompt: 'hi',
+          maxTokens: 100,
+          temperature: 0.3,
+        ),
+        throwsA(isA<LlmException>()),
+      );
+    });
+
+    test('throws when text field is missing from parts', () async {
+      final client = MockClient((request) async {
+        return _json({
+          'candidates': [
+            {
+              'content': {
+                'parts': [<String, Object>{}],
+              },
+            },
+          ],
+        });
+      });
+      final gen = GeminiGenerator(apiKey: 'k', client: client);
+
+      await expectLater(
+        gen.generate(
+          modelPath: '',
+          prompt: 'hi',
+          maxTokens: 100,
+          temperature: 0.3,
+        ),
+        throwsA(isA<LlmException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Replace on-device `flutter_gemma` LLM path with Google Gemini API (`gemini-2.5-flash`) after the 2.58 GB bundled model OOM-killed the moto g34 5G (4 GB RAM) target device
- Add `GeminiGenerator` (implements existing `GemmaGenerator` interface) + `NoopModelLoader`; wire both into `llm_providers` in place of the Flutter Gemma implementations
- Add `.env` / `flutter_dotenv` loading for `GEMINI_API_KEY`, with `--dart-define` fallback for CI/release; add connectivity guard + `E013 networkOffline` exception

Closes #16.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` (266 tests) pass
- [x] Release build + install on moto g34 5G (ZA222JQ2TV) — no `lowmemorykiller` activity, Tamil query → Tamil answer in 1-3s
- [ ] Verify offline path (airplane mode → E013 error block) post-merge
- [ ] Follow-up: strip bundled `.litertlm` + `flutter_gemma` dep (APK 2.45 GB → ~50 MB) — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)