### PR TITLE
Add TalkBack hints for record/stop FABs + history delete (refs #18)

### DIFF
--- a/lib/screens/history/history_screen.dart
+++ b/lib/screens/history/history_screen.dart
@@ -179,16 +179,19 @@ class _HistoryTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ListTile(
-      title: Text(
-        query.transcription,
-        maxLines: 2,
-        overflow: TextOverflow.ellipsis,
+    return Semantics(
+      onLongPressHint: TamilStrings.delete,
+      child: ListTile(
+        title: Text(
+          query.transcription,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Text(formatRelativeTamil(query.timestamp)),
+        trailing: _ratingIcon(query.userRating),
+        onTap: () => context.push('/response/${query.id}'),
+        onLongPress: () => _confirmDelete(context, ref),
       ),
-      subtitle: Text(formatRelativeTamil(query.timestamp)),
-      trailing: _ratingIcon(query.userRating),
-      onTap: () => context.push('/response/${query.id}'),
-      onLongPress: () => _confirmDelete(context, ref),
     );
   }
 

--- a/lib/screens/recording/widgets/recording_controls.dart
+++ b/lib/screens/recording/widgets/recording_controls.dart
@@ -33,6 +33,7 @@ class RecordingControls extends ConsumerWidget {
           height: 80,
           child: FloatingActionButton(
             heroTag: 'record_btn',
+            tooltip: TamilStrings.tapToRecord,
             onPressed: notifier.startRecording,
             backgroundColor: NilamTheme.warmAmber,
             child: const Icon(Icons.mic, size: 36, color: NilamTheme.onSurface),
@@ -69,6 +70,7 @@ class RecordingControls extends ConsumerWidget {
           height: 72,
           child: FloatingActionButton(
             heroTag: 'stop_btn',
+            tooltip: TamilStrings.stop,
             onPressed: notifier.stopRecording,
             backgroundColor: NilamTheme.redPrimary,
             child:


### PR DESCRIPTION
## Summary
- Adds `tooltip` strings to the record and stop `FloatingActionButton`s so TalkBack announces the Tamil labels (`tapToRecord`, `stop`) instead of an empty "button".
- Wraps the history `ListTile` in `Semantics(onLongPressHint: TamilStrings.delete)` so blind users discover the long-press-to-delete affordance.
- Targeted subset of the Phase 5a on-device verification checklist (#18) — the remaining checklist items (text scaling, cold-start timing, rotation, settings-persistence force-stop, clear-history with real data) still require manual device time on a Redmi 9A.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 256 tests pass
- [x] Built + launched on moto g34 (Android 15) to confirm no runtime regressions; app loads and TTS engine still connects
- [ ] **On-device verification with TalkBack ON** (to be done as part of #18):
  - Record screen mic FAB announces "பதிவு செய்ய தட்டுங்கள்"
  - Record screen stop FAB announces "நிறுத்து"
  - History long-press announces a delete hint
- [ ] Remaining #18 checklist items (text scaling 1.5×/2×, rotation, cold-start <3 s, settings persistence across force-stop, clear-history flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)