### PR TITLE
Swap Gemini for DeepInfra-hosted Gemma 4 (closes #29)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@
 # Copy this file to `.env` and fill in your values.
 # `.env` is gitignored — never commit real keys.
 #
-# Get a Gemini API key from https://aistudio.google.com/apikey
-GEMINI_API_KEY=
+# Get a DeepInfra API key from https://deepinfra.com/dash/api_keys
+DEEPINFRA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # NilamAI (நிலம்AI)
 
 Tamil agricultural advisory app for smallholder farmers in Tamil Nadu. STT
-runs on-device (Whisper); the LLM currently runs via the Google Gemini API
-(the bundled 2.58 GB on-device Gemma 4 E2B OOM-killed 4 GB RAM devices — see
-[Phase 7 plan](C:/Users/email/.claude/plans/create-complete-implemenaion-plan-glowing-crown.md)).
+runs on-device (Whisper); the LLM runs as Gemma 4 hosted on DeepInfra via its
+OpenAI-compatible chat-completions endpoint (the bundled 2.58 GB on-device
+Gemma 4 E2B OOM-killed 4 GB RAM devices).
 Full spec: [docs/srs_1.0.md](docs/srs_1.0.md).
 
 ## Prerequisites
 
 - Flutter 3.24+ / Dart SDK ^3.10.4
 - `curl` or `wget` (macOS/Linux) or PowerShell (Windows) for the Whisper model fetch
-- A Google Gemini API key — free tier from https://aistudio.google.com/apikey
+- A DeepInfra API key — https://deepinfra.com/dash/api_keys
 
 ## First-time setup
 
@@ -30,11 +30,11 @@ Install Flutter deps:
 flutter pub get
 ```
 
-Create your `.env` file from the template and fill in your Gemini key:
+Create your `.env` file from the template and fill in your DeepInfra key:
 
 ```bash
 cp .env.example .env
-# then edit .env and set GEMINI_API_KEY=<your-key>
+# then edit .env and set DEEPINFRA_API_KEY=<your-key>
 ```
 
 `.env` is gitignored — never commit real keys. Run the app:
@@ -47,10 +47,10 @@ For release builds that shouldn't ship a `.env` (e.g. CI), pass the key at
 build time instead:
 
 ```bash
-flutter build apk --release --dart-define=GEMINI_API_KEY=<your-key>
+flutter build apk --release --dart-define=DEEPINFRA_API_KEY=<your-key>
 ```
 
-`LlmConstants.geminiApiKey` reads `.env` first, then falls back to the
+`LlmConstants.deepInfraApiKey` reads `.env` first, then falls back to the
 `--dart-define` value.
 
 ## Testing

--- a/integration_test/app_flow_test.dart
+++ b/integration_test/app_flow_test.dart
@@ -155,7 +155,7 @@ void main() {
     // queryByIdProvider invalidates, then rebuild with hasStored=true.
     await _drainAsync(tester, 30);
 
-    // Response screen — canned Gemini text rendered once the listener persists
+    // Response screen — canned LLM text rendered once the listener persists
     // the response and invalidates queryByIdProvider.
     expect(find.textContaining('நெல் பயிரில்'), findsOneWidget);
     expect(find.text(TamilStrings.goHome), findsOneWidget);

--- a/lib/providers/llm_providers.dart
+++ b/lib/providers/llm_providers.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/exceptions/app_exception.dart';
 import '../core/logging/logger.dart';
-import '../services/llm/gemini_generator.dart';
+import '../services/llm/deepinfra_generator.dart';
 import '../services/llm/gemma_generator.dart';
 import '../services/llm/gemma_service.dart';
 import '../services/llm/llm_constants.dart';
@@ -47,22 +47,22 @@ class GemmaError extends GemmaState {
 // Providers
 // -----------------------------------------------------------------------------
 
-/// API-mode loader — returns an empty path; the remote [GeminiGenerator]
+/// API-mode loader — returns an empty path; the remote [DeepInfraGenerator]
 /// ignores it.
 final gemmaModelLoaderProvider = Provider<ModelLoader>((ref) {
   return NoopModelLoader();
 });
 
-/// Production generator: Gemini REST.
+/// Production generator: DeepInfra-hosted Gemma 4.
 final gemmaGeneratorProvider = Provider<GemmaGenerator>((ref) {
-  if (LlmConstants.geminiApiKey.isEmpty) {
+  if (LlmConstants.deepInfraApiKey.isEmpty) {
     throw StateError(
-      'GEMINI_API_KEY is not set. Run: flutter run '
-      '--dart-define=GEMINI_API_KEY=<your-key>. '
-      'Get a key at https://aistudio.google.com/apikey',
+      'DEEPINFRA_API_KEY is not set. Add it to `.env` or pass '
+      '--dart-define=DEEPINFRA_API_KEY=<your-key>. '
+      'Get a key at https://deepinfra.com/dash/api_keys',
     );
   }
-  return GeminiGenerator(apiKey: LlmConstants.geminiApiKey);
+  return DeepInfraGenerator(apiKey: LlmConstants.deepInfraApiKey);
 });
 
 /// Connectivity probe wired into [GemmaService]. Defaults to the real

--- a/lib/services/llm/deepinfra_generator.dart
+++ b/lib/services/llm/deepinfra_generator.dart
@@ -9,23 +9,23 @@ import '../../core/logging/logger.dart';
 import 'gemma_generator.dart';
 import 'llm_constants.dart';
 
-/// Production LLM backend that calls Google's Gemini `generateContent` REST
-/// endpoint.
+/// Production LLM backend that calls DeepInfra's OpenAI-compatible
+/// chat-completions endpoint to run Gemma 4.
 ///
 /// Implements the [GemmaGenerator] contract so callers (`GemmaService`,
 /// providers, the UI state machine) are unchanged. The `modelPath` argument
-/// is ignored; Gemini hosts the model.
-class GeminiGenerator implements GemmaGenerator {
-  GeminiGenerator({
+/// is ignored; DeepInfra hosts the model.
+class DeepInfraGenerator implements GemmaGenerator {
+  DeepInfraGenerator({
     required this.apiKey,
     String? baseUrl,
     String? model,
     http.Client? client,
-  })  : baseUrl = baseUrl ?? LlmConstants.geminiBaseUrl,
-        model = model ?? LlmConstants.geminiModel,
+  })  : baseUrl = baseUrl ?? LlmConstants.deepInfraBaseUrl,
+        model = model ?? LlmConstants.deepInfraModel,
         _client = client ?? http.Client();
 
-  static const _tag = 'GeminiGenerator';
+  static const _tag = 'DeepInfraGenerator';
 
   final String apiKey;
   final String baseUrl;
@@ -39,19 +39,14 @@ class GeminiGenerator implements GemmaGenerator {
     required int maxTokens,
     required double temperature,
   }) async {
-    final uri = Uri.parse('$baseUrl/$model:generateContent?key=$apiKey');
+    final uri = Uri.parse(baseUrl);
     final body = jsonEncode({
-      'contents': [
-        {
-          'parts': [
-            {'text': prompt},
-          ],
-        },
+      'model': model,
+      'messages': [
+        {'role': 'user', 'content': prompt},
       ],
-      'generationConfig': {
-        'maxOutputTokens': maxTokens,
-        'temperature': temperature,
-      },
+      'max_tokens': maxTokens,
+      'temperature': temperature,
     });
 
     final http.Response response;
@@ -59,7 +54,10 @@ class GeminiGenerator implements GemmaGenerator {
       response = await _client
           .post(
             uri,
-            headers: const {'Content-Type': 'application/json'},
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $apiKey',
+            },
             body: body,
           )
           .timeout(
@@ -76,15 +74,16 @@ class GeminiGenerator implements GemmaGenerator {
     if (response.statusCode != 200) {
       final bodyText = utf8.decode(response.bodyBytes, allowMalformed: true);
       AppLogger.error(
-        'Gemini HTTP ${response.statusCode}: $bodyText',
+        'DeepInfra HTTP ${response.statusCode}: $bodyText',
         _tag,
       );
       throw LlmException(
-        message: 'Gemini returned HTTP ${response.statusCode}: $bodyText',
+        message:
+            'DeepInfra returned HTTP ${response.statusCode}: $bodyText',
       );
     }
 
-    // Decode as UTF-8 directly — matches OllamaGenerator for correct Tamil.
+    // Decode as UTF-8 directly so Tamil round-trips correctly.
     final Map<String, dynamic> decoded;
     try {
       decoded = jsonDecode(utf8.decode(response.bodyBytes))
@@ -93,31 +92,24 @@ class GeminiGenerator implements GemmaGenerator {
       throw LlmException.modelNotLoaded(originalError: e);
     }
 
-    final candidates = decoded['candidates'];
-    if (candidates is! List || candidates.isEmpty) {
+    final choices = decoded['choices'];
+    if (choices is! List || choices.isEmpty) {
       throw const LlmException(
-        message: 'Gemini response missing "candidates"',
+        message: 'DeepInfra response missing "choices"',
         code: 'E009',
       );
     }
 
-    final content = (candidates.first as Map<String, dynamic>)['content'];
-    final parts = (content is Map<String, dynamic>) ? content['parts'] : null;
-    if (parts is! List || parts.isEmpty) {
+    final message = (choices.first as Map<String, dynamic>)['message'];
+    final content =
+        (message is Map<String, dynamic>) ? message['content'] : null;
+    if (content is! String || content.isEmpty) {
       throw const LlmException(
-        message: 'Gemini response missing "content.parts"',
+        message: 'DeepInfra response missing "message.content"',
         code: 'E009',
       );
     }
-
-    final text = (parts.first as Map<String, dynamic>)['text'];
-    if (text is! String || text.isEmpty) {
-      throw const LlmException(
-        message: 'Gemini response missing text',
-        code: 'E009',
-      );
-    }
-    return text;
+    return content;
   }
 
   /// Test-only — closes the underlying HTTP client.

--- a/lib/services/llm/gemma_generator.dart
+++ b/lib/services/llm/gemma_generator.dart
@@ -2,7 +2,7 @@
 /// without hitting a real network service.
 ///
 /// `modelPath` is retained for interface parity with on-device implementations
-/// — the current production backend ([GeminiGenerator]) ignores it.
+/// — the current production backend ([DeepInfraGenerator]) ignores it.
 abstract class GemmaGenerator {
   Future<String> generate({
     required String modelPath,

--- a/lib/services/llm/llm_constants.dart
+++ b/lib/services/llm/llm_constants.dart
@@ -2,8 +2,8 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 /// LLM configuration constants for NilamAI.
 ///
-/// Production backend is the Google Gemini API (`gemini-2.5-flash`) via
-/// `generativelanguage.googleapis.com`; see [GeminiGenerator].
+/// Production backend is DeepInfra-hosted Gemma 4 via the OpenAI-compatible
+/// chat-completions endpoint; see [DeepInfraGenerator].
 class LlmConstants {
   LlmConstants._();
 
@@ -13,18 +13,24 @@ class LlmConstants {
   static const double temperature = 0.3;
   static const int inferenceTimeoutSeconds = 30;
 
-  // -- Gemini API (production backend) --
-  static const String geminiBaseUrl =
-      'https://generativelanguage.googleapis.com/v1beta/models';
-  static const String geminiModel = 'gemini-2.5-flash';
+  // -- DeepInfra (Gemma 4, OpenAI-compatible endpoint) --
+  static const String deepInfraBaseUrl =
+      'https://api.deepinfra.com/v1/openai/chat/completions';
+
+  /// Primary: MoE variant, 4B active params — lower latency/cost.
+  static const String deepInfraModel = 'google/gemma-4-26B-A4B-it';
+
+  /// Fallback (dense 31B) — swap the line above if Tamil quality is weak.
+  // static const String deepInfraModel = 'google/gemma-4-31B-it';
 
   /// Loaded from `.env` (see `.env.example`) at app start via `dotenv.load()`.
-  /// Falls back to the compile-time `--dart-define=GEMINI_API_KEY=...` if set
-  /// so CI and release builds can still inject a key without a `.env` file.
-  static String get geminiApiKey {
-    final fromDotenv = dotenv.maybeGet('GEMINI_API_KEY') ?? '';
+  /// Falls back to the compile-time `--dart-define=DEEPINFRA_API_KEY=...` if
+  /// set so CI and release builds can still inject a key without a `.env`
+  /// file.
+  static String get deepInfraApiKey {
+    final fromDotenv = dotenv.maybeGet('DEEPINFRA_API_KEY') ?? '';
     if (fromDotenv.isNotEmpty) return fromDotenv;
-    return const String.fromEnvironment('GEMINI_API_KEY', defaultValue: '');
+    return const String.fromEnvironment('DEEPINFRA_API_KEY', defaultValue: '');
   }
 
   // -- Language --

--- a/lib/services/llm/model_loader.dart
+++ b/lib/services/llm/model_loader.dart
@@ -1,8 +1,9 @@
 /// Swap point for resolving a model file path before inference.
 ///
 /// Implementations return the absolute path to a model file that the active
-/// [GemmaGenerator] can consume. Remote generators (e.g. [GeminiGenerator])
-/// pair this with a no-op loader that returns an empty path.
+/// [GemmaGenerator] can consume. Remote generators (e.g.
+/// [DeepInfraGenerator]) pair this with a no-op loader that returns an empty
+/// path.
 abstract class ModelLoader {
   Future<String> ensureModelAvailable();
 }

--- a/lib/services/llm/noop_model_loader.dart
+++ b/lib/services/llm/noop_model_loader.dart
@@ -1,7 +1,7 @@
 import 'model_loader.dart';
 
 /// Stand-in [ModelLoader] when the active generator is remote (e.g.
-/// [GeminiGenerator]). Returns an empty path that the remote generator
+/// [DeepInfraGenerator]). Returns an empty path that the remote generator
 /// ignores; keeps [GemmaService] unchanged.
 class NoopModelLoader implements ModelLoader {
   NoopModelLoader();

--- a/test/services/llm/deepinfra_generator_test.dart
+++ b/test/services/llm/deepinfra_generator_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:nilam_ai/core/exceptions/app_exception.dart';
-import 'package:nilam_ai/services/llm/gemini_generator.dart';
+import 'package:nilam_ai/services/llm/deepinfra_generator.dart';
 
 http.Response _json(Object body, [int status = 200]) => http.Response.bytes(
       utf8.encode(jsonEncode(body)),
@@ -15,27 +15,27 @@ http.Response _json(Object body, [int status = 200]) => http.Response.bytes(
     );
 
 void main() {
-  group('GeminiGenerator.generate', () {
-    test('POSTs prompt to v1beta endpoint and returns Tamil text', () async {
+  group('DeepInfraGenerator.generate', () {
+    test('POSTs OpenAI-shaped body to DeepInfra and returns Tamil text',
+        () async {
       http.Request? captured;
       final client = MockClient((request) async {
         captured = request;
         return _json({
-          'candidates': [
+          'choices': [
             {
-              'content': {
-                'parts': [
-                  {'text': 'தக்காளிச் செடிக்கு நீம் எண்ணெய் பயன்படுத்துங்கள்.'},
-                ],
+              'message': {
+                'role': 'assistant',
+                'content': 'தக்காளிச் செடிக்கு நீம் எண்ணெய் பயன்படுத்துங்கள்.',
               },
             },
           ],
         });
       });
 
-      final gen = GeminiGenerator(
+      final gen = DeepInfraGenerator(
         apiKey: 'test-key',
-        model: 'gemini-1.5-flash-latest',
+        model: 'google/gemma-4-26B-A4B-it',
         client: client,
       );
 
@@ -52,27 +52,30 @@ void main() {
       );
       expect(captured, isNotNull);
       expect(captured!.method, equals('POST'));
-      expect(captured!.url.host, equals('generativelanguage.googleapis.com'));
+      expect(captured!.url.host, equals('api.deepinfra.com'));
       expect(
         captured!.url.path,
-        equals('/v1beta/models/gemini-1.5-flash-latest:generateContent'),
+        equals('/v1/openai/chat/completions'),
       );
-      expect(captured!.url.queryParameters['key'], equals('test-key'));
+      expect(
+        captured!.headers['authorization'],
+        equals('Bearer test-key'),
+      );
 
       final decoded = jsonDecode(captured!.body) as Map<String, dynamic>;
-      final parts =
-          ((decoded['contents'] as List).first as Map)['parts'] as List;
-      expect((parts.first as Map)['text'], equals('test prompt'));
-      final cfg = decoded['generationConfig'] as Map;
-      expect(cfg['maxOutputTokens'], equals(300));
-      expect(cfg['temperature'], equals(0.3));
+      expect(decoded['model'], equals('google/gemma-4-26B-A4B-it'));
+      final messages = decoded['messages'] as List;
+      expect((messages.first as Map)['role'], equals('user'));
+      expect((messages.first as Map)['content'], equals('test prompt'));
+      expect(decoded['max_tokens'], equals(300));
+      expect(decoded['temperature'], equals(0.3));
     });
 
-    test('throws LlmException on non-200 status (e.g. 400 auth)', () async {
+    test('throws LlmException on non-200 status (e.g. 401 auth)', () async {
       final client = MockClient((request) async {
-        return http.Response('bad api key', 400);
+        return http.Response('bad api key', 401);
       });
-      final gen = GeminiGenerator(apiKey: 'bad-key', client: client);
+      final gen = DeepInfraGenerator(apiKey: 'bad-key', client: client);
 
       await expectLater(
         gen.generate(
@@ -89,7 +92,7 @@ void main() {
       final client = MockClient((request) async {
         throw const SocketException('no route to host');
       });
-      final gen = GeminiGenerator(apiKey: 'k', client: client);
+      final gen = DeepInfraGenerator(apiKey: 'k', client: client);
 
       try {
         await gen.generate(
@@ -108,7 +111,7 @@ void main() {
       final client = MockClient((request) async {
         throw TimeoutException('slow');
       });
-      final gen = GeminiGenerator(apiKey: 'k', client: client);
+      final gen = DeepInfraGenerator(apiKey: 'k', client: client);
 
       try {
         await gen.generate(
@@ -123,11 +126,11 @@ void main() {
       }
     });
 
-    test('throws when candidates array is empty', () async {
+    test('throws when choices array is empty', () async {
       final client = MockClient((request) async {
-        return _json({'candidates': <Object>[]});
+        return _json({'choices': <Object>[]});
       });
-      final gen = GeminiGenerator(apiKey: 'k', client: client);
+      final gen = DeepInfraGenerator(apiKey: 'k', client: client);
 
       await expectLater(
         gen.generate(
@@ -144,7 +147,7 @@ void main() {
       final client = MockClient((request) async {
         return http.Response('<html>oops</html>', 200);
       });
-      final gen = GeminiGenerator(apiKey: 'k', client: client);
+      final gen = DeepInfraGenerator(apiKey: 'k', client: client);
 
       await expectLater(
         gen.generate(
@@ -157,19 +160,17 @@ void main() {
       );
     });
 
-    test('throws when text field is missing from parts', () async {
+    test('throws when message.content is missing', () async {
       final client = MockClient((request) async {
         return _json({
-          'candidates': [
+          'choices': [
             {
-              'content': {
-                'parts': [<String, Object>{}],
-              },
+              'message': <String, Object>{'role': 'assistant'},
             },
           ],
         });
       });
-      final gen = GeminiGenerator(apiKey: 'k', client: client);
+      final gen = DeepInfraGenerator(apiKey: 'k', client: client);
 
       await expectLater(
         gen.generate(


### PR DESCRIPTION
## Summary

- Replace `GeminiGenerator` with `DeepInfraGenerator` behind the existing `GemmaGenerator` interface — hits DeepInfra's OpenAI-compatible chat-completions endpoint with `google/gemma-4-26B-A4B-it` (MoE, 4B active, 256K ctx). Dense `google/gemma-4-31B-it` left as a commented fallback in `LlmConstants`.
- Service-layer-only swap: `GemmaService`, `gemmaNotifierProvider`, connectivity/E013 pre-flight, `PromptBuilder`, `ResponsePostProcessor`, UI screens, and integration-test `_FakeGenerator` are all unchanged.
- Env var renamed `GEMINI_API_KEY` → `DEEPINFRA_API_KEY`. README + `.env.example` updated to point at https://deepinfra.com/dash/api_keys.
- `gemini_generator.dart` + `gemini_generator_test.dart` deleted (tracked as renames in git — new test mirrors the 7 original cases against the OpenAI wire format).

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — 256 tests pass, including 7 new cases in `deepinfra_generator_test.dart`
- [x] `flutter test integration_test/app_flow_test.dart` — both scenarios pass (fakes implement `GemmaGenerator` directly, swap is transparent)
- [x] Manual smoke test on moto g34 — happy path: Tamil voice query → Gemma response rendered correctly

## Notes for reviewer

- Wire differences from Gemini to Gemma via DeepInfra: auth is `Authorization: Bearer` header (not `?key=` query param); request shape is OpenAI-standard `{model, messages, max_tokens, temperature}`; response path is `choices[0].message.content`.
- Inference knobs (`maxOutputTokens=300`, `temperature=0.3`, 30s timeout) preserved verbatim.
- After merge, anyone pulling the branch needs to add `DEEPINFRA_API_KEY=<key>` to their local `.env` before running.

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)